### PR TITLE
Fix USB attach crash and missing bug report prompt.

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -380,7 +380,9 @@ disk list.
 
 USB errors show a "Report this as a bug" button that opens the bug report
 dialog pre-populated with `BugReportType::Usb`, which captures the usbredir
-channel's pcap traffic.
+channel's pcap traffic. Generic channel errors (displayed in the central
+panel) also offer a bug report button pre-populated with
+`BugReportType::Connection`.
 
 ## Capture Mode
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -189,6 +189,25 @@ freeze.
 2. If the problem persists, check whether a network appliance
    between client and server has an unusually short idle timeout
 
+## USB Issues
+
+### Connection drops when attaching a USB device
+
+**Symptom:** All channels disconnect shortly after a USB device is
+connected. The QEMU log may show "usbredirparser: error invalid
+packet" or an assertion failure in `redirect.c`.
+
+**Causes:**
+- Protocol mismatch between ryll and the QEMU usbredirparser version
+- Server rejecting a message with unexpected length or type
+
+**Solutions:**
+1. Check the QEMU/libvirt log for the exact error message
+2. Submit a bug report — the "Report this as a bug" button appears on
+   both USB errors (in the USB panel) and generic channel errors (in
+   the main display area)
+3. Use `--capture <DIR>` to record pcap traffic for analysis
+
 ## Performance Issues
 
 ### High CPU usage
@@ -311,6 +330,7 @@ Use a bug report when you see:
    - **Input** — captures keyboard/mouse state and recent events.
    - **Cursor** — captures the cursor cache and position.
    - **Connection** — captures session info and main channel traffic.
+   - **USB** — captures usbredir channel and device state.
 4. Optionally enter a brief **description** of what you observed.
 5. Click **Capture**.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1216,13 +1216,25 @@ impl eframe::App for RyllApp {
         }
 
         // Main display area (no margin so the surface fills edge-to-edge)
+        let mut open_channel_bug_report = false;
         let panel_frame = egui::Frame::none().inner_margin(0.0);
         egui::CentralPanel::default()
             .frame(panel_frame)
             .show(ctx, |ui| {
                 ui.spacing_mut().item_spacing = egui::vec2(0.0, 0.0);
-                if let Some(error) = &self.error_message {
-                    ui.colored_label(egui::Color32::RED, format!("Error: {}", error));
+                if self.error_message.is_some() {
+                    ui.colored_label(
+                        egui::Color32::RED,
+                        format!("Error: {}", self.error_message.as_ref().unwrap()),
+                    );
+                    ui.horizontal(|ui| {
+                        if ui.small_button("Dismiss").clicked() {
+                            self.error_message = None;
+                        }
+                        if ui.small_button("Report this as a bug").clicked() {
+                            open_channel_bug_report = true;
+                        }
+                    });
                     ui.separator();
                 }
 
@@ -1344,6 +1356,13 @@ impl eframe::App for RyllApp {
                     });
                 }
             });
+
+        // Open bug report dialog for channel error (two-pass)
+        if open_channel_bug_report {
+            self.show_bug_dialog = true;
+            self.bug_report_type = BugReportType::Connection;
+            self.bug_description = self.error_message.clone().unwrap_or_default();
+        }
 
         // Bug report dialog (two-pass: render then act)
         let mut dialog_action = None;
@@ -1811,8 +1830,16 @@ async fn run_connection(
 
     // Wait for all channel tasks
     for handle in handles {
-        if let Err(e) = handle.await {
-            error!("Channel task error: {}", e);
+        match handle.await {
+            Err(e) => {
+                error!("Channel task panic: {}", e);
+            }
+            Ok(Err(e)) => {
+                let msg = format!("channel error: {}", e);
+                error!("app: {}", msg);
+                event_tx.send(ChannelEvent::Error(msg)).await.ok();
+            }
+            Ok(Ok(())) => {}
         }
     }
 

--- a/src/usb/real.rs
+++ b/src/usb/real.rs
@@ -159,7 +159,8 @@ impl RealDevice {
             ep_max_packet_size: [0u16; 32],
         };
         let mut iface_info = InterfaceInfo {
-            interface_count: [0u8; 32],
+            interface_count: 0,
+            interface: [0u8; 32],
             interface_class: [0u8; 32],
             interface_subclass: [0u8; 32],
             interface_protocol: [0u8; 32],
@@ -173,12 +174,13 @@ impl RealDevice {
 
             // Read interface descriptor
             if let Some(desc) = iface.descriptor() {
-                let idx = iface_num as usize;
+                let idx = iface_info.interface_count as usize;
                 if idx < 32 {
-                    iface_info.interface_count[idx] = 1;
+                    iface_info.interface[idx] = iface_num;
                     iface_info.interface_class[idx] = desc.class();
                     iface_info.interface_subclass[idx] = desc.subclass();
                     iface_info.interface_protocol[idx] = desc.protocol();
+                    iface_info.interface_count += 1;
 
                     // Read endpoint descriptors
                     for ep_desc in desc.endpoints() {

--- a/src/usb/virtual_msc.rs
+++ b/src/usb/virtual_msc.rs
@@ -708,12 +708,13 @@ impl UsbDeviceBackend for VirtualMsc {
 
     fn interface_info(&self) -> InterfaceInfo {
         let mut info = InterfaceInfo {
-            interface_count: [0u8; 32],
+            interface_count: 1,
+            interface: [0u8; 32],
             interface_class: [0u8; 32],
             interface_subclass: [0u8; 32],
             interface_protocol: [0u8; 32],
         };
-        info.interface_count[0] = 1;
+        info.interface[0] = 0; // Interface number 0
         info.interface_class[0] = 0x08; // Mass Storage
         info.interface_subclass[0] = 0x06; // SCSI
         info.interface_protocol[0] = 0x50; // Bulk-Only Transport

--- a/src/usbredir/messages.rs
+++ b/src/usbredir/messages.rs
@@ -9,7 +9,7 @@
 #![allow(dead_code)]
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use std::io::{self, Cursor};
+use std::io::{self, Cursor, Read};
 
 // ── Header ─────────────────────────────────────────────
 
@@ -147,17 +147,25 @@ impl DeviceConnect {
     }
 }
 
-/// InterfaceInfo (type 4) — 128 bytes.
+/// InterfaceInfo (type 4) — 132 bytes.
+///
+/// Wire format (little-endian):
+///   u32  interface_count          — number of valid entries
+///   u8   interface[32]            — interface numbers
+///   u8   interface_class[32]
+///   u8   interface_subclass[32]
+///   u8   interface_protocol[32]
 #[derive(Debug, Clone)]
 pub struct InterfaceInfo {
-    pub interface_count: [u8; 32],
+    pub interface_count: u32,
+    pub interface: [u8; 32],
     pub interface_class: [u8; 32],
     pub interface_subclass: [u8; 32],
     pub interface_protocol: [u8; 32],
 }
 
 impl InterfaceInfo {
-    pub const SIZE: usize = 128;
+    pub const SIZE: usize = 132;
 
     pub fn read(data: &[u8]) -> io::Result<Self> {
         if data.len() < Self::SIZE {
@@ -166,21 +174,28 @@ impl InterfaceInfo {
                 "not enough data for InterfaceInfo",
             ));
         }
-        let mut info = InterfaceInfo {
-            interface_count: [0u8; 32],
-            interface_class: [0u8; 32],
-            interface_subclass: [0u8; 32],
-            interface_protocol: [0u8; 32],
-        };
-        info.interface_count.copy_from_slice(&data[0..32]);
-        info.interface_class.copy_from_slice(&data[32..64]);
-        info.interface_subclass.copy_from_slice(&data[64..96]);
-        info.interface_protocol.copy_from_slice(&data[96..128]);
-        Ok(info)
+        let mut rdr = io::Cursor::new(data);
+        let interface_count = rdr.read_u32::<LittleEndian>()?;
+        let mut interface = [0u8; 32];
+        let mut interface_class = [0u8; 32];
+        let mut interface_subclass = [0u8; 32];
+        let mut interface_protocol = [0u8; 32];
+        rdr.read_exact(&mut interface)?;
+        rdr.read_exact(&mut interface_class)?;
+        rdr.read_exact(&mut interface_subclass)?;
+        rdr.read_exact(&mut interface_protocol)?;
+        Ok(InterfaceInfo {
+            interface_count,
+            interface,
+            interface_class,
+            interface_subclass,
+            interface_protocol,
+        })
     }
 
     pub fn write(&self, buf: &mut Vec<u8>) -> io::Result<()> {
-        buf.extend_from_slice(&self.interface_count);
+        buf.write_u32::<LittleEndian>(self.interface_count)?;
+        buf.extend_from_slice(&self.interface);
         buf.extend_from_slice(&self.interface_class);
         buf.extend_from_slice(&self.interface_subclass);
         buf.extend_from_slice(&self.interface_protocol);
@@ -695,12 +710,13 @@ mod tests {
     #[test]
     fn interface_info_round_trip() {
         let mut orig = InterfaceInfo {
-            interface_count: [0u8; 32],
+            interface_count: 1,
+            interface: [0u8; 32],
             interface_class: [0u8; 32],
             interface_subclass: [0u8; 32],
             interface_protocol: [0u8; 32],
         };
-        orig.interface_count[0] = 1;
+        orig.interface[0] = 0;
         orig.interface_class[0] = 0x08;
         orig.interface_subclass[0] = 0x06;
         orig.interface_protocol[0] = 0x50;
@@ -708,7 +724,8 @@ mod tests {
         orig.write(&mut buf).unwrap();
         assert_eq!(buf.len(), InterfaceInfo::SIZE);
         let parsed = InterfaceInfo::read(&buf).unwrap();
-        assert_eq!(parsed.interface_count[0], 1);
+        assert_eq!(parsed.interface_count, 1);
+        assert_eq!(parsed.interface[0], 0);
         assert_eq!(parsed.interface_class[0], 0x08);
         assert_eq!(parsed.interface_protocol[0], 0x50);
     }


### PR DESCRIPTION
Fix three issues discovered from a macOS USB disk attach session that crashed QEMU:

1. InterfaceInfo was missing the leading u32 interface_count field. The usbredir protocol specifies 132 bytes but ryll sent 128, causing QEMU to reject the packet with "invalid packet type 4 length: 128" and crash with an assertion failure. Add the missing field, rename the old interface_count array to interface (interface numbers), and fix all consumers.

2. Generic channel errors (ChannelEvent::Error) were shown as plain red text with no bug report button. Add Dismiss and Report buttons matching the USB error panel pattern.

3. Channel task errors returned via Result::Err were silently dropped in run_connection because only JoinError (panics) was checked. Now inner errors are logged and forwarded as ChannelEvent::Error.

Prompt: The capture subdirectory contains a capture of a session which crashed when I tried to attach a virtual USB disk on macos. The error reported was a TLS close_notify on the inputs channel. QEMU logged "invalid packet type 4 length: 128" and an assertion failure.


Assisted-By: Claude Code