### PR TITLE
Fix SpiceCursorHeader wire format: flags u32→u16, cursor_type u16→u8

### DIFF
--- a/docs/plans/PLAN-cursor-rendering-phase-01-parse.md
+++ b/docs/plans/PLAN-cursor-rendering-phase-01-parse.md
@@ -23,28 +23,29 @@ forward to the app via a new `CursorShape` channel event.
 ```
 Offset  Size  Field
 ------  ----  -----------
-0       4     flags (u32 LE)
-                bit 0: (unused)
+0       2     flags (u16 LE)
+                bit 0: NONE — no cursor data follows
                 bit 1: CACHE_ME — client should cache this
                 bit 2: FROM_CACHE — no pixel data follows;
                         look up by unique_id
-4       8     unique_id (u64 LE)
-12      2     cursor_type (u16 LE)
-14      2     width (u16 LE)
-16      2     height (u16 LE)
-18      2     hot_spot_x (u16 LE)
-20      2     hot_spot_y (u16 LE)
-22      var   pixel_data (only if FROM_CACHE is NOT set)
+2       8     unique_id (u64 LE)
+10      1     cursor_type (u8)
+11      2     width (u16 LE)
+13      2     height (u16 LE)
+15      2     hot_spot_x (u16 LE)
+17      2     hot_spot_y (u16 LE)
+19      var   pixel_data (only if FROM_CACHE is NOT set)
 ```
 
-Total header size: 22 bytes.
+Total header size: 19 bytes (flags + header fields).
+When FLAG_NONE is set, only the 2-byte flags field is present.
 
 ### Where SpiceCursor appears
 
 - **CURSOR_INIT** (opcode 101): 9 bytes of position/trail/
-  visible, then SpiceCursor if payload > 9 + 22 bytes.
+  visible, then SpiceCursor if payload > 9 + 2 bytes.
 - **CURSOR_SET** (opcode 103): 5 bytes of position/visible,
-  then SpiceCursor if payload > 5 + 22 bytes.
+  then SpiceCursor if payload > 5 + 2 bytes.
 
 ### Pixel data formats (by cursor_type)
 
@@ -65,9 +66,9 @@ In `protocol/messages.rs`, add:
 
 ```rust
 pub struct SpiceCursorHeader {
-    pub flags: u32,
+    pub flags: u16,
     pub unique_id: u64,
-    pub cursor_type: u16,
+    pub cursor_type: u8,
     pub width: u16,
     pub height: u16,
     pub hot_spot_x: u16,
@@ -75,12 +76,14 @@ pub struct SpiceCursorHeader {
 }
 ```
 
-With `const SIZE: usize = 22` and a standard `read()`
-method. Define flag constants:
+With `const FLAGS_SIZE: usize = 2`, `const SIZE: usize = 19`,
+and a `read()` method that returns `Option<Self>` (None when
+FLAG_NONE is set). Define flag constants:
 
 ```rust
-pub const CURSOR_FLAG_CACHE_ME: u32 = 1 << 1;
-pub const CURSOR_FLAG_FROM_CACHE: u32 = 1 << 2;
+pub const FLAG_NONE: u16 = 1 << 0;
+pub const FLAG_CACHE_ME: u16 = 1 << 1;
+pub const FLAG_FROM_CACHE: u16 = 1 << 2;
 ```
 
 ### Step 2: Add CursorImage type and CursorShape event
@@ -114,10 +117,12 @@ cursor_cache: HashMap<u64, CursorImage>,
 ### Step 4: Parse SpiceCursor in INIT and SET handlers
 
 After reading the position/visible fields, check whether
-the payload is large enough to contain a SpiceCursor
-header (22 more bytes). If so:
+the payload is large enough to contain the SpiceCursor
+flags (2 more bytes). If so:
 
 1. Parse `SpiceCursorHeader` from the remaining payload.
+   If `read()` returns `None` (FLAG_NONE set), there is no
+   cursor data — return early.
 2. If `FROM_CACHE` flag is set: look up `unique_id` in
    `cursor_cache` and emit `CursorShape` with the cached
    image. If not found, log a warning.

--- a/src/channels/cursor.rs
+++ b/src/channels/cursor.rs
@@ -314,13 +314,16 @@ impl CursorChannel {
 
     /// Parse SpiceCursor data and emit a CursorShape event if successful.
     async fn parse_and_emit_cursor(&mut self, data: &[u8]) {
-        if data.len() < SpiceCursorHeader::SIZE {
-            // No cursor data in this message
+        if data.len() < SpiceCursorHeader::FLAGS_SIZE {
             return;
         }
 
         let header = match SpiceCursorHeader::read(data) {
-            Ok(h) => h,
+            Ok(Some(h)) => h,
+            Ok(None) => {
+                debug!("cursor: FLAG_NONE set, no cursor data");
+                return;
+            }
             Err(e) => {
                 warn!("cursor: failed to parse SpiceCursorHeader: {}", e);
                 return;
@@ -344,7 +347,6 @@ impl CursorChannel {
         );
 
         if from_cache {
-            // Look up cached cursor by unique_id
             if let Some(img) = self.cursor_cache.get(&header.unique_id) {
                 info!("cursor: using cached cursor id={}", header.unique_id);
                 self.event_tx
@@ -361,7 +363,6 @@ impl CursorChannel {
             return;
         }
 
-        // Pixel data follows the header
         let pixel_data = &data[SpiceCursorHeader::SIZE..];
         let image = decode_cursor_pixels(&header, pixel_data);
 
@@ -527,17 +528,17 @@ mod tests {
     use super::*;
 
     fn build_cursor_payload(
-        cursor_type: u16,
+        cursor_type: u8,
         width: u16,
         height: u16,
-        flags: u32,
+        flags: u16,
         pixel_data: &[u8],
     ) -> Vec<u8> {
         let mut buf = Vec::new();
-        // SpiceCursorHeader: flags(4) + unique_id(8) + type(2) + w(2) + h(2) + hx(2) + hy(2)
+        // SpiceCursor: flags(2) + unique_id(8) + type(1) + w(2) + h(2) + hx(2) + hy(2)
         buf.extend_from_slice(&flags.to_le_bytes());
         buf.extend_from_slice(&1u64.to_le_bytes()); // unique_id = 1
-        buf.extend_from_slice(&cursor_type.to_le_bytes());
+        buf.push(cursor_type);
         buf.extend_from_slice(&width.to_le_bytes());
         buf.extend_from_slice(&height.to_le_bytes());
         buf.extend_from_slice(&0u16.to_le_bytes()); // hot_spot_x
@@ -548,7 +549,6 @@ mod tests {
 
     #[test]
     fn test_alpha_cursor_argb_to_rgba() {
-        // 2x2 alpha cursor: BGRA pixels
         let pixels: Vec<u8> = vec![
             0x10, 0x20, 0x30, 0x80, // B=0x10, G=0x20, R=0x30, A=0x80
             0x40, 0x50, 0x60, 0xFF, // B=0x40, G=0x50, R=0x60, A=0xFF
@@ -556,7 +556,7 @@ mod tests {
             0xFF, 0xFF, 0xFF, 0xFF, // opaque white
         ];
         let data = build_cursor_payload(0, 2, 2, 0, &pixels);
-        let header = SpiceCursorHeader::read(&data).unwrap();
+        let header = SpiceCursorHeader::read(&data).unwrap().unwrap();
         let result = decode_cursor_pixels(&header, &data[SpiceCursorHeader::SIZE..]);
         assert!(result.is_some());
 
@@ -586,10 +586,9 @@ mod tests {
 
     #[test]
     fn test_color32_cursor_xrgb_to_rgba() {
-        // 1x1 color32 cursor: BGRX pixel
         let pixels: Vec<u8> = vec![0xAA, 0xBB, 0xCC, 0x00]; // B=AA, G=BB, R=CC, x=00
         let data = build_cursor_payload(6, 1, 1, 0, &pixels);
-        let header = SpiceCursorHeader::read(&data).unwrap();
+        let header = SpiceCursorHeader::read(&data).unwrap().unwrap();
         let result = decode_cursor_pixels(&header, &data[SpiceCursorHeader::SIZE..]);
         assert!(result.is_some());
 
@@ -599,9 +598,8 @@ mod tests {
 
     #[test]
     fn test_from_cache_flag_no_pixel_data() {
-        // Header with FROM_CACHE flag — no pixel data expected
         let data = build_cursor_payload(0, 24, 24, SpiceCursorHeader::FLAG_FROM_CACHE, &[]);
-        let header = SpiceCursorHeader::read(&data).unwrap();
+        let header = SpiceCursorHeader::read(&data).unwrap().unwrap();
         assert_eq!(
             header.flags & SpiceCursorHeader::FLAG_FROM_CACHE,
             SpiceCursorHeader::FLAG_FROM_CACHE
@@ -611,9 +609,16 @@ mod tests {
     }
 
     #[test]
+    fn test_flag_none_returns_none() {
+        let data = build_cursor_payload(0, 24, 24, SpiceCursorHeader::FLAG_NONE, &[]);
+        let result = SpiceCursorHeader::read(&data).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
     fn test_zero_dimension_cursor_returns_none() {
         let data = build_cursor_payload(0, 0, 0, 0, &[]);
-        let header = SpiceCursorHeader::read(&data).unwrap();
+        let header = SpiceCursorHeader::read(&data).unwrap().unwrap();
         let result = decode_cursor_pixels(&header, &data[SpiceCursorHeader::SIZE..]);
         assert!(result.is_none());
     }

--- a/src/channels/inputs.rs
+++ b/src/channels/inputs.rs
@@ -414,6 +414,13 @@ impl InputsChannel {
             }
 
             InputEvent::MouseUp { button, x, y } => {
+                // Send position before button release (as spice-gtk does)
+                let mut pos_payload = Vec::new();
+                MousePosition::write(x, y, self.button_state, 0, &mut pos_payload)?;
+                let pos_msg = make_message(inputs_client::MOUSE_POSITION, &pos_payload);
+                self.send_with_log(inputs_client::MOUSE_POSITION, &pos_msg)
+                    .await?;
+
                 self.button_state &= !button;
 
                 self.record_event(InputEventRecord {

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -397,12 +397,17 @@ impl CursorSet {
     }
 }
 
-/// SpiceCursor header — precedes cursor pixel data in INIT and SET messages
+/// SpiceCursor — flags field that precedes the optional SpiceCursorHeader.
+///
+/// Wire layout:
+///   u16 flags
+///   [SpiceCursorHeader]  — only present when FLAG_NONE is NOT set
+///   [pixel data]         — only present when FLAG_FROM_CACHE is NOT set
 #[derive(Debug, Clone)]
 pub struct SpiceCursorHeader {
-    pub flags: u32,
+    pub flags: u16,
     pub unique_id: u64,
-    pub cursor_type: u16,
+    pub cursor_type: u8,
     pub width: u16,
     pub height: u16,
     pub hot_spot_x: u16,
@@ -410,14 +415,32 @@ pub struct SpiceCursorHeader {
 }
 
 impl SpiceCursorHeader {
-    pub const SIZE: usize = 22;
+    /// Size of just the flags field (always present).
+    pub const FLAGS_SIZE: usize = 2;
+    /// Size of flags + cursor header (when header is present).
+    pub const SIZE: usize = 19;
 
-    /// Cursor should be cached by unique_id
-    pub const FLAG_CACHE_ME: u32 = 1 << 1;
-    /// No pixel data follows — look up by unique_id
-    pub const FLAG_FROM_CACHE: u32 = 1 << 2;
+    pub const FLAG_NONE: u16 = 1 << 0;
+    pub const FLAG_CACHE_ME: u16 = 1 << 1;
+    pub const FLAG_FROM_CACHE: u16 = 1 << 2;
 
-    pub fn read(data: &[u8]) -> io::Result<Self> {
+    /// Read the flags field and, if FLAG_NONE is not set, the full header.
+    /// Returns None when FLAG_NONE is set (no cursor data follows).
+    pub fn read(data: &[u8]) -> io::Result<Option<Self>> {
+        if data.len() < Self::FLAGS_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Not enough data for SpiceCursor flags",
+            ));
+        }
+
+        let mut cursor = Cursor::new(data);
+        let flags = cursor.read_u16::<LittleEndian>()?;
+
+        if flags & Self::FLAG_NONE != 0 {
+            return Ok(None);
+        }
+
         if data.len() < Self::SIZE {
             return Err(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
@@ -425,16 +448,15 @@ impl SpiceCursorHeader {
             ));
         }
 
-        let mut cursor = Cursor::new(data);
-        Ok(SpiceCursorHeader {
-            flags: cursor.read_u32::<LittleEndian>()?,
+        Ok(Some(SpiceCursorHeader {
+            flags,
             unique_id: cursor.read_u64::<LittleEndian>()?,
-            cursor_type: cursor.read_u16::<LittleEndian>()?,
+            cursor_type: cursor.read_u8()?,
             width: cursor.read_u16::<LittleEndian>()?,
             height: cursor.read_u16::<LittleEndian>()?,
             hot_spot_x: cursor.read_u16::<LittleEndian>()?,
             hot_spot_y: cursor.read_u16::<LittleEndian>()?,
-        })
+        }))
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix SpiceCursor header parsing that used wrong field sizes (flags as u32 instead of u16, cursor_type as u16 instead of u8), causing a 3-byte offset that corrupted all subsequent fields
- Add FLAG_NONE (bit 0) handling — when set, no cursor header or pixel data follows
- Send MOUSE_POSITION before MOUSE_RELEASE to match spice-gtk behavior

## Problem

Running ryll produced `WARN cursor: unsupported cursor type 16384 (1792x1024)` — the 1792x1024 is the display surface size, not a cursor size. The root cause was wrong field widths in SpiceCursorHeader causing a 3-byte parse offset.

## Verified against

- spice-html5 (`spicetype.js`) — flags is u16, cursor_type is u8
- spice_viewer (`channels/cursor.rs`) — same wire layout, also handles FLAG_NONE