### PR TITLE
Fix display rendering, add QUIC decode, multi-monitor and agent support

### DIFF
--- a/docs/plans/PLAN-cursor-rendering-phase-01-parse.md
+++ b/docs/plans/PLAN-cursor-rendering-phase-01-parse.md
@@ -23,28 +23,29 @@ forward to the app via a new `CursorShape` channel event.
 ```
 Offset  Size  Field
 ------  ----  -----------
-0       4     flags (u32 LE)
-                bit 0: (unused)
+0       2     flags (u16 LE)
+                bit 0: NONE — no cursor data follows
                 bit 1: CACHE_ME — client should cache this
                 bit 2: FROM_CACHE — no pixel data follows;
                         look up by unique_id
-4       8     unique_id (u64 LE)
-12      2     cursor_type (u16 LE)
-14      2     width (u16 LE)
-16      2     height (u16 LE)
-18      2     hot_spot_x (u16 LE)
-20      2     hot_spot_y (u16 LE)
-22      var   pixel_data (only if FROM_CACHE is NOT set)
+2       8     unique_id (u64 LE)
+10      1     cursor_type (u8)
+11      2     width (u16 LE)
+13      2     height (u16 LE)
+15      2     hot_spot_x (u16 LE)
+17      2     hot_spot_y (u16 LE)
+19      var   pixel_data (only if FROM_CACHE is NOT set)
 ```
 
-Total header size: 22 bytes.
+Total header size: 19 bytes (flags + header fields).
+When FLAG_NONE is set, only the 2-byte flags field is present.
 
 ### Where SpiceCursor appears
 
 - **CURSOR_INIT** (opcode 101): 9 bytes of position/trail/
-  visible, then SpiceCursor if payload > 9 + 22 bytes.
+  visible, then SpiceCursor if payload > 9 + 2 bytes.
 - **CURSOR_SET** (opcode 103): 5 bytes of position/visible,
-  then SpiceCursor if payload > 5 + 22 bytes.
+  then SpiceCursor if payload > 5 + 2 bytes.
 
 ### Pixel data formats (by cursor_type)
 
@@ -65,9 +66,9 @@ In `protocol/messages.rs`, add:
 
 ```rust
 pub struct SpiceCursorHeader {
-    pub flags: u32,
+    pub flags: u16,
     pub unique_id: u64,
-    pub cursor_type: u16,
+    pub cursor_type: u8,
     pub width: u16,
     pub height: u16,
     pub hot_spot_x: u16,
@@ -75,12 +76,14 @@ pub struct SpiceCursorHeader {
 }
 ```
 
-With `const SIZE: usize = 22` and a standard `read()`
-method. Define flag constants:
+With `const FLAGS_SIZE: usize = 2`, `const SIZE: usize = 19`,
+and a `read()` method that returns `Option<Self>` (None when
+FLAG_NONE is set). Define flag constants:
 
 ```rust
-pub const CURSOR_FLAG_CACHE_ME: u32 = 1 << 1;
-pub const CURSOR_FLAG_FROM_CACHE: u32 = 1 << 2;
+pub const FLAG_NONE: u16 = 1 << 0;
+pub const FLAG_CACHE_ME: u16 = 1 << 1;
+pub const FLAG_FROM_CACHE: u16 = 1 << 2;
 ```
 
 ### Step 2: Add CursorImage type and CursorShape event
@@ -114,10 +117,12 @@ cursor_cache: HashMap<u64, CursorImage>,
 ### Step 4: Parse SpiceCursor in INIT and SET handlers
 
 After reading the position/visible fields, check whether
-the payload is large enough to contain a SpiceCursor
-header (22 more bytes). If so:
+the payload is large enough to contain the SpiceCursor
+flags (2 more bytes). If so:
 
 1. Parse `SpiceCursorHeader` from the remaining payload.
+   If `read()` returns `None` (FLAG_NONE set), there is no
+   cursor data — return early.
 2. If `FROM_CACHE` flag is set: look up `unique_id` in
    `cursor_cache` and emit `CursorShape` with the cached
    image. If not found, log a warning.

--- a/scripts/replay_draw_copy.py
+++ b/scripts/replay_draw_copy.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+LINE_RE = re.compile(
+    r"(?P<ts>\d{4}-\d{2}-\d{2}T[^\s]+)?.*"
+    r"surface=(?P<surface>\d+),\s*"
+    r"pos=\((?P<x>\d+),(?P<y>\d+)\),\s*"
+    r"size=(?P<w>\d+)x(?P<h>\d+),\s*"
+    r"type=Some\((?P<typ>[^)]+)\),\s*"
+    r"id=(?P<id>\d+),\s*flags=(?P<flags>\d+),\s*data_bytes=(?P<data_bytes>\d+)"
+)
+
+
+def parse_events(log_path: Path):
+    events = []
+    min_x = min_y = 10**9
+    max_x = max_y = 0
+
+    with log_path.open("r", encoding="utf-8", errors="ignore") as f:
+        for line in f:
+            line = ANSI_RE.sub("", line)
+            m = LINE_RE.search(line)
+            if not m:
+                continue
+
+            x = int(m.group("x"))
+            y = int(m.group("y"))
+            w = int(m.group("w"))
+            h = int(m.group("h"))
+            evt = {
+                "ts": m.group("ts") or "n/a",
+                "surface": int(m.group("surface")),
+                "x": x,
+                "y": y,
+                "w": w,
+                "h": h,
+                "type": m.group("typ"),
+                "id": m.group("id"),
+                "data_bytes": int(m.group("data_bytes")),
+            }
+            events.append(evt)
+
+            min_x = min(min_x, x)
+            min_y = min(min_y, y)
+            max_x = max(max_x, x + w)
+            max_y = max(max_y, y + h)
+
+    if not events:
+        raise SystemExit("No draw_copy lines found in log.")
+
+    bounds = {
+        "min_x": 0 if min_x == 10**9 else min_x,
+        "min_y": 0 if min_y == 10**9 else min_y,
+        "width": max(1, max_x - (0 if min_x == 10**9 else min_x)),
+        "height": max(1, max_y - (0 if min_y == 10**9 else min_y)),
+    }
+    return events, bounds
+
+
+HTML_TMPL = """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>draw_copy replay</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 16px; }
+    .row { display: flex; gap: 16px; align-items: flex-start; }
+    canvas { border: 1px solid #333; background: #f8fafc; }
+    .panel { min-width: 320px; }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; white-space: pre-wrap; }
+    button, input { margin-right: 8px; }
+  </style>
+</head>
+<body>
+  <h3>SPICE draw_copy replay</h3>
+  <div>Events: <b id="count">__EVENT_COUNT__</b> | Surface bounds: <b id="bounds">__BOUNDS_TEXT__</b> | Progress: <b id="progress">0</b></div>
+  <div id="status" style="margin:6px 0;color:#b00020;font-weight:600;"></div>
+  <div style="margin: 8px 0;">
+    <button id="play" type="button">Play</button>
+    <button id="pause" type="button">Pause</button>
+    <button id="step" type="button">Step</button>
+    <button id="clear" type="button">Clear</button>
+    Speed: <input id="speed" type="range" min="1" max="120" value="30" />
+    <span id="speedv">30</span> ev/s
+  </div>
+  <div class="row">
+    <canvas id="cv" width="960" height="600"></canvas>
+    <div class="panel">
+      <div class="mono" id="meta"></div>
+      <hr/>
+      <div class="mono" id="evt"></div>
+    </div>
+  </div>
+<script>
+const EVENTS = __EVENTS__;
+const BOUNDS = __BOUNDS__;
+
+const cv = document.getElementById('cv');
+const ctx = cv.getContext('2d');
+const evtBox = document.getElementById('evt');
+const meta = document.getElementById('meta');
+const count = document.getElementById('count');
+const boundsEl = document.getElementById('bounds');
+const progress = document.getElementById('progress');
+const statusEl = document.getElementById('status');
+const speed = document.getElementById('speed');
+const speedv = document.getElementById('speedv');
+
+window.onerror = (msg, src, line, col) => {
+  statusEl.textContent = `JS error: ${msg} @ ${line}:${col}`;
+};
+
+try {
+  count.textContent = EVENTS.length;
+  boundsEl.textContent = `${BOUNDS.width}x${BOUNDS.height}`;
+} catch (e) {
+  statusEl.textContent = `JS init failed: ${e}`;
+}
+
+const sx = cv.width / BOUNDS.width;
+const sy = cv.height / BOUNDS.height;
+
+meta.textContent = [
+  `Scale: ${sx.toFixed(3)} x ${sy.toFixed(3)}`,
+  `This is region replay (not pixel replay)`,
+  `Legend: blocks show where draw_copy updated`,
+  `Colors by type: GlzRgb=cyan, LzRgb=green, Quic=orange, others=magenta`,
+].join('\\n');
+
+function colorForType(t) {
+  if (t === 'GlzRgb') return 'rgba(0,170,255,1.0)';
+  if (t === 'LzRgb') return 'rgba(0,200,120,1.0)';
+  if (t === 'Quic') return 'rgba(255,140,0,1.0)';
+  return 'rgba(200,0,200,1.0)';
+}
+
+let idx = 0;
+let timer = null;
+
+function clearCanvas() {
+  ctx.fillStyle = '#f8fafc';
+  ctx.fillRect(0, 0, cv.width, cv.height);
+  ctx.strokeStyle = 'rgba(0,0,0,0.08)';
+  for (let x = 0; x < cv.width; x += 40) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, cv.height);
+    ctx.stroke();
+  }
+  for (let y = 0; y < cv.height; y += 40) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(cv.width, y);
+    ctx.stroke();
+  }
+}
+
+function drawEvent(e) {
+  const x = (e.x - BOUNDS.min_x) * sx;
+  const y = (e.y - BOUNDS.min_y) * sy;
+  const w = Math.max(1, e.w * sx);
+  const h = Math.max(1, e.h * sy);
+  ctx.fillStyle = colorForType(e.type);
+  ctx.fillRect(x, y, w, h);
+  ctx.strokeStyle = 'rgba(0,0,0,0.95)';
+  ctx.strokeRect(x, y, w, h);
+
+  evtBox.textContent = [
+    `#${idx}/${EVENTS.length}`,
+    `ts=${e.ts}`,
+    `surface=${e.surface}`,
+    `type=${e.type}`,
+    `pos=(${e.x},${e.y}) size=${e.w}x${e.h}`,
+    `data_bytes=${e.data_bytes}`,
+    `id=${e.id}`,
+  ].join('\\n');
+  progress.textContent = `${idx}/${EVENTS.length}`;
+}
+
+function stepOnce() {
+  if (idx >= EVENTS.length) return false;
+  const e = EVENTS[idx++];
+  drawEvent(e);
+  return true;
+}
+
+function play() {
+  if (idx >= EVENTS.length) {
+    idx = 0;
+    clearCanvas();
+  }
+  if (timer) return;
+  statusEl.textContent = 'Playing...';
+  timer = setInterval(() => {
+    if (!stepOnce()) {
+      clearInterval(timer);
+      timer = null;
+      statusEl.textContent = 'Finished';
+    }
+  }, 1000 / Number(speed.value));
+}
+
+function pause() {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}
+
+document.getElementById('play').onclick = play;
+document.getElementById('pause').onclick = pause;
+document.getElementById('step').onclick = () => stepOnce();
+document.getElementById('clear').onclick = () => { pause(); idx = 0; clearCanvas(); evtBox.textContent = ''; };
+speed.oninput = () => {
+  speedv.textContent = speed.value;
+  if (timer) { pause(); play(); }
+};
+
+clearCanvas();
+if (EVENTS.length > 0) {
+  statusEl.textContent = 'Ready';
+} else {
+  statusEl.textContent = 'No draw_copy events parsed from log';
+}
+</script>
+</body>
+</html>
+"""
+
+
+def write_html(out_path: Path, events, bounds):
+    html = HTML_TMPL.replace("__EVENTS__", json.dumps(events)).replace(
+        "__BOUNDS__", json.dumps(bounds)
+    )
+    html = html.replace("__EVENT_COUNT__", str(len(events)))
+    html = html.replace("__BOUNDS_TEXT__", f"{bounds['width']}x{bounds['height']}")
+    out_path.write_text(html, encoding="utf-8")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Replay SPICE draw_copy log as animation")
+    ap.add_argument("log", type=Path, help="ryll log file")
+    ap.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("draw_copy_replay.html"),
+        help="output HTML file",
+    )
+    args = ap.parse_args()
+
+    events, bounds = parse_events(args.log)
+    write_html(args.output, events, bounds)
+    print(f"Wrote {args.output} with {len(events)} events, bounds={bounds['width']}x{bounds['height']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app.rs
+++ b/src/app.rs
@@ -125,9 +125,11 @@ pub struct RyllApp {
     // Communication channels
     event_rx: mpsc::Receiver<ChannelEvent>,
     input_tx: Option<mpsc::Sender<InputEvent>>,
+    resize_tx: Option<Arc<mpsc::Sender<(u32, u32)>>>,
+    last_sent_resize: Option<(u32, u32)>,
 
     // Display state
-    surfaces: HashMap<u32, DisplaySurface>,
+    surfaces: HashMap<(u8, u32), DisplaySurface>,
 
     // Cursor state
     cursor_pos: (u16, u16),
@@ -244,12 +246,15 @@ impl RyllApp {
         virtual_disks: Vec<VirtualDiskConfig>,
         share_dir: Option<ShareDirConfig>,
         capture: Option<Arc<CaptureSession>>,
+        monitors: u8,
     ) -> Self {
         // Create event and command channels
         let (event_tx, event_rx) = mpsc::channel(EVENT_CHANNEL_SIZE);
         let (input_tx, input_rx) = mpsc::channel(INPUT_CHANNEL_SIZE);
         let (usb_tx, usb_rx) = mpsc::channel(16);
         let (webdav_tx, webdav_rx) = mpsc::channel(16);
+        let (resize_tx, resize_rx) = mpsc::channel(32);
+        let resize_tx = Arc::new(resize_tx);
 
         // Shared byte counter for bandwidth tracking
         let byte_counter = Arc::new(ByteCounter::new());
@@ -274,6 +279,7 @@ impl RyllApp {
         // Spawn connection task
         let config_clone = config.clone();
         let event_tx_clone = event_tx.clone();
+        let resize_rx_for_conn = resize_rx;
         let ctx = cc.egui_ctx.clone();
         let capture_clone = capture.clone();
         let counter_clone = byte_counter.clone();
@@ -300,6 +306,8 @@ impl RyllApp {
                     counter_clone,
                     traffic_clone,
                     snaps_for_conn,
+                    monitors,
+                    resize_rx_for_conn,
                 )
                 .await
                 {
@@ -313,6 +321,8 @@ impl RyllApp {
         RyllApp {
             event_rx,
             input_tx: Some(input_tx),
+            resize_tx: Some(resize_tx),
+            last_sent_resize: None,
             surfaces: HashMap::new(),
             cursor_pos: (0, 0),
             cursor_visible: true,
@@ -390,22 +400,32 @@ impl RyllApp {
                 }
 
                 ChannelEvent::SurfaceCreated {
+                    display_channel_id,
                     surface_id,
                     width,
                     height,
                 } => {
-                    info!("app: surface {} created: {}x{}", surface_id, width, height);
-                    self.surfaces
-                        .insert(surface_id, DisplaySurface::new(surface_id, width, height));
+                    info!(
+                        "app: surface {}:{} created: {}x{}",
+                        display_channel_id, surface_id, width, height
+                    );
+                    self.surfaces.insert(
+                        (display_channel_id, surface_id),
+                        DisplaySurface::new(surface_id, width, height),
+                    );
                     self.pending_resize = Some((width as f32, height as f32));
                 }
 
-                ChannelEvent::SurfaceDestroyed { surface_id } => {
-                    info!("app: surface {} destroyed", surface_id);
-                    self.surfaces.remove(&surface_id);
+                ChannelEvent::SurfaceDestroyed {
+                    display_channel_id,
+                    surface_id,
+                } => {
+                    info!("app: surface {}:{} destroyed", display_channel_id, surface_id);
+                    self.surfaces.remove(&(display_channel_id, surface_id));
                 }
 
                 ChannelEvent::ImageReady {
+                    display_channel_id,
                     surface_id,
                     left,
                     top,
@@ -417,7 +437,7 @@ impl RyllApp {
                     // Auto-create surface if the server draws before sending
                     // SURFACE_CREATE (QEMU does this for the primary surface).
                     if let std::collections::hash_map::Entry::Vacant(e) =
-                        self.surfaces.entry(surface_id)
+                        self.surfaces.entry((display_channel_id, surface_id))
                     {
                         let surf_w = left + width;
                         let surf_h = top + height;
@@ -429,7 +449,10 @@ impl RyllApp {
                         self.pending_resize = Some((surf_w as f32, surf_h as f32));
                     }
 
-                    let surface = self.surfaces.get_mut(&surface_id).unwrap();
+                    let surface = self
+                        .surfaces
+                        .get_mut(&(display_channel_id, surface_id))
+                        .unwrap();
                     surface.blit(left, top, width, height, &pixels);
                     self.stats.frames_received += 1;
                     debug!(
@@ -448,7 +471,11 @@ impl RyllApp {
 
                     // Capture a video frame if enabled
                     if let Some(ref capture) = self.capture {
-                        if let Some(surface) = self.surfaces.get(&0) {
+                        if let Some(surface) = self
+                            .surfaces
+                            .values()
+                            .max_by_key(|s| (s.width as u64) * (s.height as u64))
+                        {
                             capture.frame(0, surface.pixels(), surface.width, surface.height);
                         }
                     }
@@ -476,6 +503,10 @@ impl RyllApp {
                         if mode == 1 { "server" } else { "client" }
                     );
                     self.mouse_mode = mode;
+                }
+
+                ChannelEvent::MonitorsConfig { width, height } => {
+                    debug!("app: requested monitors config {}x{}", width, height);
                 }
 
                 ChannelEvent::Statistics {
@@ -629,7 +660,8 @@ impl RyllApp {
         // Get surface pixels for display reports
         let surface_data = if report_type == BugReportType::Display {
             self.surfaces
-                .get(&0)
+                .values()
+                .max_by_key(|s| (s.width as u64) * (s.height as u64))
                 .map(|s| (s.pixels(), s.width, s.height))
         } else {
             None
@@ -737,6 +769,40 @@ impl RyllApp {
             }
         }
     }
+
+    fn maybe_send_monitors_resize(&mut self, ctx: &egui::Context) {
+        let Some(tx) = &self.resize_tx else {
+            return;
+        };
+
+        let viewport_size = ctx.input(|i| {
+            i.viewport()
+                .inner_rect
+                .map(|rect| rect.size())
+                .unwrap_or_else(|| i.screen_rect().size())
+        });
+
+        let mut width = viewport_size.x.max(0.0) as u32;
+        let mut height = (viewport_size.y - STATS_BAR_HEIGHT).max(0.0) as u32;
+
+        width -= width % 8;
+        height -= height % 8;
+        width = width.max(8);
+        height = height.max(8);
+
+        if self.last_sent_resize.is_none() {
+            self.last_sent_resize = Some((width, height));
+            return;
+        }
+
+        if self.last_sent_resize == Some((width, height)) {
+            return;
+        }
+
+        if tx.try_send((width, height)).is_ok() {
+            self.last_sent_resize = Some((width, height));
+        }
+    }
 }
 
 impl eframe::App for RyllApp {
@@ -756,14 +822,11 @@ impl eframe::App for RyllApp {
         self.process_events();
 
         // Resize viewport to match the remote surface (plus stats bar)
-        if let Some((w, h)) = self.pending_resize.take() {
-            let total_h = h + STATS_BAR_HEIGHT;
-            info!(
-                "app: resizing viewport to {}x{} (surface {}x{})",
-                w, total_h, w, h
-            );
-            ctx.send_viewport_cmd(egui::ViewportCommand::InnerSize(egui::vec2(w, total_h)));
+        if let Some((_w, _h)) = self.pending_resize.take() {
+            debug!("app: surface resize {}x{} (not resizing window)", _w, _h);
         }
+
+        self.maybe_send_monitors_resize(ctx);
 
         // Tick the bandwidth tracker
         self.bandwidth.tick();
@@ -1433,108 +1496,93 @@ impl eframe::App for RyllApp {
                     return;
                 }
 
-                // Display surfaces
-                for surface in self.surfaces.values_mut() {
-                    let width = surface.width;
-                    let height = surface.height;
-                    let texture = surface.texture(ctx);
-                    let size = egui::vec2(width as f32, height as f32);
+                let mut keys: Vec<(u8, u32)> = self.surfaces.keys().copied().collect();
+                keys.sort_unstable();
+                let primary_key = keys
+                    .iter()
+                    .copied()
+                    .find(|(_, sid)| *sid == 0)
+                    .or_else(|| keys.first().copied());
 
-                    let response = ui.add(
-                        egui::Image::new(texture)
-                            .fit_to_exact_size(size)
-                            .sense(egui::Sense::click_and_drag()),
-                    );
+                if let Some(primary_key) = primary_key {
+                    if let Some(surface) = self.surfaces.get_mut(&primary_key) {
+                        let width = surface.width;
+                        let height = surface.height;
+                        let texture = surface.texture(ctx);
+                        let size = egui::vec2(width as f32, height as f32);
 
-                    // Track the surface rect for cursor overlay positioning
-                    self.surface_rect = response.rect;
+                        let response = ui.add(
+                            egui::Image::new(texture)
+                                .fit_to_exact_size(size)
+                                .sense(egui::Sense::click_and_drag()),
+                        );
 
-                    // Hide the OS cursor when hovering over the surface
-                    // (show crosshair during region selection instead)
-                    if response.hovered()
-                        && !self.region_select_active
-                        && self.cursor_image.is_some()
-                    {
-                        ui.ctx()
-                            .output_mut(|o| o.cursor_icon = egui::CursorIcon::None);
-                    }
+                        self.surface_rect = response.rect;
 
-                    // Handle mouse input on the surface (suppressed during dialog/selection)
-                    let input_suppressed = self.show_bug_dialog || self.region_select_active;
-                    if !input_suppressed {
-                        if let Some(tx) = &self.input_tx {
-                            // Send mouse position only when it changes
-                            if let Some(pos) = response.hover_pos() {
-                                let x = (pos.x - response.rect.min.x).max(0.0) as u32;
-                                let y = (pos.y - response.rect.min.y).max(0.0) as u32;
-                                if self.last_mouse_pos != Some((x, y)) {
-                                    self.last_mouse_pos = Some((x, y));
-                                    let _ = tx.try_send(InputEvent::MouseMove { x, y });
+                        if response.hovered()
+                            && !self.region_select_active
+                            && self.cursor_image.is_some()
+                        {
+                            ui.ctx()
+                                .output_mut(|o| o.cursor_icon = egui::CursorIcon::None);
+                        }
+
+                        let input_suppressed = self.show_bug_dialog || self.region_select_active;
+                        if !input_suppressed {
+                            if let Some(tx) = &self.input_tx {
+                                if let Some(pos) = response.hover_pos() {
+                                    let x = (pos.x - response.rect.min.x).max(0.0) as u32;
+                                    let y = (pos.y - response.rect.min.y).max(0.0) as u32;
+                                    if self.last_mouse_pos != Some((x, y)) {
+                                        self.last_mouse_pos = Some((x, y));
+                                        let _ = tx.try_send(InputEvent::MouseMove { x, y });
+                                    }
                                 }
-                            }
 
-                            // Mouse buttons — use the raw pointer state from egui
-                            // so press and release are sent at the correct times,
-                            // not batched together on release like clicked_by().
-                            ctx.input(|i| {
+                                ctx.input(|i| {
+                                    let pos = self.last_mouse_pos.unwrap_or((0, 0));
+                                    for button in [
+                                        egui::PointerButton::Primary,
+                                        egui::PointerButton::Secondary,
+                                        egui::PointerButton::Middle,
+                                    ] {
+                                        if i.pointer.button_pressed(button) {
+                                            let spice_btn = mouse_button_to_spice(button);
+                                            self.forwarded_buttons |= spice_btn;
+                                            let _ = tx.try_send(InputEvent::MouseDown {
+                                                button: spice_btn,
+                                                x: pos.0,
+                                                y: pos.1,
+                                            });
+                                        }
+                                        if i.pointer.button_released(button) {
+                                            let spice_btn = mouse_button_to_spice(button);
+                                            self.forwarded_buttons &= !spice_btn;
+                                            let _ = tx.try_send(InputEvent::MouseUp {
+                                                button: spice_btn,
+                                                x: pos.0,
+                                                y: pos.1,
+                                            });
+                                        }
+                                    }
+                                });
+                            }
+                        } else if self.forwarded_buttons != 0 {
+                            if let Some(tx) = &self.input_tx {
                                 let pos = self.last_mouse_pos.unwrap_or((0, 0));
-                                for button in [
-                                    egui::PointerButton::Primary,
-                                    egui::PointerButton::Secondary,
-                                    egui::PointerButton::Middle,
-                                ] {
-                                    if i.pointer.button_pressed(button) {
-                                        let spice_btn = mouse_button_to_spice(button);
-                                        self.forwarded_buttons |= spice_btn;
-                                        let _ = tx.try_send(InputEvent::MouseDown {
-                                            button: spice_btn,
-                                            x: pos.0,
-                                            y: pos.1,
-                                        });
-                                        debug!(
-                                            "app: mouse down {:?} at ({},{})",
-                                            button, pos.0, pos.1
-                                        );
-                                    }
-                                    if i.pointer.button_released(button) {
-                                        let spice_btn = mouse_button_to_spice(button);
-                                        self.forwarded_buttons &= !spice_btn;
+                                for bit in 0..5u32 {
+                                    let mask = 1 << bit;
+                                    if self.forwarded_buttons & mask != 0 {
                                         let _ = tx.try_send(InputEvent::MouseUp {
-                                            button: spice_btn,
+                                            button: mask,
                                             x: pos.0,
                                             y: pos.1,
                                         });
-                                        debug!(
-                                            "app: mouse up {:?} at ({},{})",
-                                            button, pos.0, pos.1
-                                        );
                                     }
-                                }
-                            });
-                        }
-                    } else if self.forwarded_buttons != 0 {
-                        // Input forwarding just became suppressed (e.g. the
-                        // bug report dialog opened) while one or more mouse
-                        // buttons were held.  Send synthetic releases so the
-                        // server doesn't stay in a stuck "button held" state.
-                        if let Some(tx) = &self.input_tx {
-                            let pos = self.last_mouse_pos.unwrap_or((0, 0));
-                            for bit in 0..5u32 {
-                                let mask = 1 << bit;
-                                if self.forwarded_buttons & mask != 0 {
-                                    let _ = tx.try_send(InputEvent::MouseUp {
-                                        button: mask,
-                                        x: pos.0,
-                                        y: pos.1,
-                                    });
-                                    debug!(
-                                        "app: synthetic mouse up button={} at ({},{})",
-                                        mask, pos.0, pos.1
-                                    );
                                 }
                             }
+                            self.forwarded_buttons = 0;
                         }
-                        self.forwarded_buttons = 0;
                     }
                 }
 
@@ -1866,6 +1914,8 @@ async fn run_connection(
     byte_counter: Arc<ByteCounter>,
     traffic: Arc<TrafficBuffers>,
     snapshots: ChannelSnapshots,
+    monitors: u8,
+    resize_rx: mpsc::Receiver<(u32, u32)>,
 ) -> Result<()> {
     let client = SpiceClient::new(config)?;
 
@@ -1883,6 +1933,8 @@ async fn run_connection(
         byte_counter.clone(),
         traffic.clone(),
         snapshots.main,
+        resize_rx,
+        monitors,
     );
 
     // Spawn main channel task
@@ -1936,6 +1988,7 @@ async fn run_connection(
     let mut handles = vec![main_handle];
     let mut usb_rx = Some(usb_rx);
     let mut webdav_rx = Some(webdav_rx);
+    let shared_glz_dictionary = DisplayChannel::new_shared_glz_dictionary();
 
     for (channel_type, channel_id) in channels {
         match channel_type {
@@ -1944,12 +1997,14 @@ async fn run_connection(
                     .connect_channel(session_id, channel_type, channel_id)
                     .await?;
                 let mut channel = DisplayChannel::new(
+                    channel_id,
                     stream,
                     event_tx.clone(),
                     capture.clone(),
                     byte_counter.clone(),
                     traffic.clone(),
                     snapshots.display.clone(),
+                    shared_glz_dictionary.clone(),
                 );
                 handles.push(tokio::spawn(async move { channel.run().await }));
             }
@@ -2066,6 +2121,7 @@ pub async fn run_headless(
     virtual_disks: Vec<VirtualDiskConfig>,
     share_dir: Option<ShareDirConfig>,
     capture: Option<Arc<CaptureSession>>,
+    monitors: u8,
 ) -> Result<()> {
     info!("Running in headless mode");
 
@@ -2076,6 +2132,7 @@ pub async fn run_headless(
     let (input_tx, input_rx) = mpsc::channel(INPUT_CHANNEL_SIZE);
     let (_usb_tx, usb_rx) = mpsc::channel(16);
     let (_webdav_tx, webdav_rx) = mpsc::channel(16);
+    let (_resize_tx, resize_rx) = mpsc::channel(32);
 
     // Headless mode doesn't display bandwidth, but channels still need the counter
     let byte_counter = Arc::new(ByteCounter::new());
@@ -2100,6 +2157,8 @@ pub async fn run_headless(
             byte_counter,
             traffic,
             snapshots,
+            monitors,
+            resize_rx,
         )
         .await
     });
@@ -2129,6 +2188,8 @@ pub async fn run_headless(
                 match event {
                     ChannelEvent::SessionInitialized(id) => {
                         info!("Session {} initialized", id);
+                    }
+                    ChannelEvent::SurfaceCreated { .. } => {
                     }
                     ChannelEvent::ImageReady { .. } => {
                         stats.frames_received += 1;

--- a/src/channels/cursor.rs
+++ b/src/channels/cursor.rs
@@ -314,13 +314,16 @@ impl CursorChannel {
 
     /// Parse SpiceCursor data and emit a CursorShape event if successful.
     async fn parse_and_emit_cursor(&mut self, data: &[u8]) {
-        if data.len() < SpiceCursorHeader::SIZE {
-            // No cursor data in this message
+        if data.len() < SpiceCursorHeader::FLAGS_SIZE {
             return;
         }
 
         let header = match SpiceCursorHeader::read(data) {
-            Ok(h) => h,
+            Ok(Some(h)) => h,
+            Ok(None) => {
+                debug!("cursor: FLAG_NONE set, no cursor data");
+                return;
+            }
             Err(e) => {
                 warn!("cursor: failed to parse SpiceCursorHeader: {}", e);
                 return;
@@ -344,7 +347,6 @@ impl CursorChannel {
         );
 
         if from_cache {
-            // Look up cached cursor by unique_id
             if let Some(img) = self.cursor_cache.get(&header.unique_id) {
                 info!("cursor: using cached cursor id={}", header.unique_id);
                 self.event_tx
@@ -361,7 +363,6 @@ impl CursorChannel {
             return;
         }
 
-        // Pixel data follows the header
         let pixel_data = &data[SpiceCursorHeader::SIZE..];
         let image = decode_cursor_pixels(&header, pixel_data);
 
@@ -527,17 +528,17 @@ mod tests {
     use super::*;
 
     fn build_cursor_payload(
-        cursor_type: u16,
+        cursor_type: u8,
         width: u16,
         height: u16,
-        flags: u32,
+        flags: u16,
         pixel_data: &[u8],
     ) -> Vec<u8> {
         let mut buf = Vec::new();
-        // SpiceCursorHeader: flags(4) + unique_id(8) + type(2) + w(2) + h(2) + hx(2) + hy(2)
+        // SpiceCursor: flags(2) + unique_id(8) + type(1) + w(2) + h(2) + hx(2) + hy(2)
         buf.extend_from_slice(&flags.to_le_bytes());
         buf.extend_from_slice(&1u64.to_le_bytes()); // unique_id = 1
-        buf.extend_from_slice(&cursor_type.to_le_bytes());
+        buf.push(cursor_type);
         buf.extend_from_slice(&width.to_le_bytes());
         buf.extend_from_slice(&height.to_le_bytes());
         buf.extend_from_slice(&0u16.to_le_bytes()); // hot_spot_x
@@ -548,7 +549,6 @@ mod tests {
 
     #[test]
     fn test_alpha_cursor_argb_to_rgba() {
-        // 2x2 alpha cursor: BGRA pixels
         let pixels: Vec<u8> = vec![
             0x10, 0x20, 0x30, 0x80, // B=0x10, G=0x20, R=0x30, A=0x80
             0x40, 0x50, 0x60, 0xFF, // B=0x40, G=0x50, R=0x60, A=0xFF
@@ -556,7 +556,7 @@ mod tests {
             0xFF, 0xFF, 0xFF, 0xFF, // opaque white
         ];
         let data = build_cursor_payload(0, 2, 2, 0, &pixels);
-        let header = SpiceCursorHeader::read(&data).unwrap();
+        let header = SpiceCursorHeader::read(&data).unwrap().unwrap();
         let result = decode_cursor_pixels(&header, &data[SpiceCursorHeader::SIZE..]);
         assert!(result.is_some());
 
@@ -586,10 +586,9 @@ mod tests {
 
     #[test]
     fn test_color32_cursor_xrgb_to_rgba() {
-        // 1x1 color32 cursor: BGRX pixel
         let pixels: Vec<u8> = vec![0xAA, 0xBB, 0xCC, 0x00]; // B=AA, G=BB, R=CC, x=00
         let data = build_cursor_payload(6, 1, 1, 0, &pixels);
-        let header = SpiceCursorHeader::read(&data).unwrap();
+        let header = SpiceCursorHeader::read(&data).unwrap().unwrap();
         let result = decode_cursor_pixels(&header, &data[SpiceCursorHeader::SIZE..]);
         assert!(result.is_some());
 
@@ -599,9 +598,8 @@ mod tests {
 
     #[test]
     fn test_from_cache_flag_no_pixel_data() {
-        // Header with FROM_CACHE flag — no pixel data expected
         let data = build_cursor_payload(0, 24, 24, SpiceCursorHeader::FLAG_FROM_CACHE, &[]);
-        let header = SpiceCursorHeader::read(&data).unwrap();
+        let header = SpiceCursorHeader::read(&data).unwrap().unwrap();
         assert_eq!(
             header.flags & SpiceCursorHeader::FLAG_FROM_CACHE,
             SpiceCursorHeader::FLAG_FROM_CACHE
@@ -611,9 +609,16 @@ mod tests {
     }
 
     #[test]
+    fn test_flag_none_returns_none() {
+        let data = build_cursor_payload(0, 24, 24, SpiceCursorHeader::FLAG_NONE, &[]);
+        let result = SpiceCursorHeader::read(&data).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
     fn test_zero_dimension_cursor_returns_none() {
         let data = build_cursor_payload(0, 0, 0, 0, &[]);
-        let header = SpiceCursorHeader::read(&data).unwrap();
+        let header = SpiceCursorHeader::read(&data).unwrap().unwrap();
         let result = decode_cursor_pixels(&header, &data[SpiceCursorHeader::SIZE..]);
         assert!(result.is_none());
     }

--- a/src/channels/display.rs
+++ b/src/channels/display.rs
@@ -10,7 +10,7 @@ use tracing::{debug, info, warn};
 use crate::app::ByteCounter;
 use crate::bugreport::{DecodeResult, DisplaySnapshot, TrafficBuffers};
 use crate::capture::CaptureSession;
-use crate::decompression::{decompress_glz, decompress_lz, DecompressedImage};
+use crate::decompression::{decompress_glz, decompress_lz, quic_decode, DecompressedImage};
 use crate::protocol::link::SpiceStream;
 use crate::protocol::logging::{self, message_names};
 use crate::protocol::messages::{
@@ -33,12 +33,12 @@ fn decompress_spice_lz4(data: &[u8], width: usize, height: usize) -> Option<Deco
         return None;
     }
 
-    let _top_down = data[0];
+    let top_down = data[0] != 0;
     let spice_format = data[1];
 
     debug!(
         "display: LZ4 header: top_down={}, format={}, first_16_bytes={:02x?}",
-        _top_down,
+        top_down,
         spice_format,
         &data[..data.len().min(16)]
     );
@@ -97,7 +97,8 @@ fn decompress_spice_lz4(data: &[u8], width: usize, height: usize) -> Option<Deco
         offset += enc_size;
 
         // Convert decoded row to RGBA
-        let dst_row_start = row * width * 4;
+        let dst_row = if top_down { row } else { height - 1 - row };
+        let dst_row_start = dst_row * width * 4;
         match bpp {
             4 => {
                 // BGRX or BGRA → RGBA
@@ -139,18 +140,22 @@ fn decompress_spice_lz4(data: &[u8], width: usize, height: usize) -> Option<Deco
         height: height as u32,
         pixels: rgba,
         image_id: 0,
-        win_head_dist: None,
     })
 }
 
 /// Maximum number of recent decode results to keep in the snapshot.
 const MAX_RECENT_DECODES: usize = 20;
 
+/// GLZ dictionary shared across all display channels.
+pub type SharedGlzDictionary = Arc<Mutex<HashMap<u64, Vec<u8>>>>;
+
 pub struct DisplayChannel {
+    channel_id: u8,
     stream: SpiceStream,
     event_tx: mpsc::Sender<ChannelEvent>,
     buffer: Vec<u8>,
-    previous_images: HashMap<u64, Vec<u8>>,
+    glz_dictionary: SharedGlzDictionary,
+    image_cache: HashMap<u64, Vec<u8>>,
     capture: Option<Arc<CaptureSession>>,
     byte_counter: Arc<ByteCounter>,
     traffic: Arc<TrafficBuffers>,
@@ -165,19 +170,27 @@ pub struct DisplayChannel {
 }
 
 impl DisplayChannel {
+    pub fn new_shared_glz_dictionary() -> SharedGlzDictionary {
+        Arc::new(Mutex::new(HashMap::new()))
+    }
+
     pub fn new(
+        channel_id: u8,
         stream: SpiceStream,
         event_tx: mpsc::Sender<ChannelEvent>,
         capture: Option<Arc<CaptureSession>>,
         byte_counter: Arc<ByteCounter>,
         traffic: Arc<TrafficBuffers>,
         snapshot: Arc<Mutex<DisplaySnapshot>>,
+        glz_dictionary: SharedGlzDictionary,
     ) -> Self {
         DisplayChannel {
+            channel_id,
             stream,
             event_tx,
-            buffer: Vec::with_capacity(1024 * 1024), // 1MB buffer for images
-            previous_images: HashMap::new(),
+            buffer: Vec::with_capacity(1024 * 1024),
+            glz_dictionary,
+            image_cache: HashMap::new(),
             capture,
             byte_counter,
             traffic,
@@ -312,8 +325,8 @@ impl DisplayChannel {
             display_server::SURFACE_CREATE => {
                 let surface = SurfaceCreate::read(payload)?;
                 info!(
-                    "display: surface created: id={}, {}x{}",
-                    surface.surface_id, surface.width, surface.height
+                    "display: surface created: channel={}, id={}, {}x{}",
+                    self.channel_id, surface.surface_id, surface.width, surface.height
                 );
 
                 if settings::is_verbose() {
@@ -329,6 +342,7 @@ impl DisplayChannel {
 
                 self.event_tx
                     .send(ChannelEvent::SurfaceCreated {
+                        display_channel_id: self.channel_id,
                         surface_id: surface.surface_id,
                         width: surface.width,
                         height: surface.height,
@@ -348,7 +362,10 @@ impl DisplayChannel {
                     }
 
                     self.event_tx
-                        .send(ChannelEvent::SurfaceDestroyed { surface_id })
+                        .send(ChannelEvent::SurfaceDestroyed {
+                            display_channel_id: self.channel_id,
+                            surface_id,
+                        })
                         .await
                         .ok();
                 }
@@ -363,7 +380,46 @@ impl DisplayChannel {
             }
 
             display_server::MONITORS_CONFIG => {
-                debug!("display: monitors_config received (acknowledged, not acted on)");
+                if payload.len() >= 8 {
+                    let count = u16::from_le_bytes([payload[0], payload[1]]);
+                    let max_allowed = u16::from_le_bytes([payload[2], payload[3]]);
+                    info!(
+                        "display: monitors_config: count={}, max_allowed={}, channel_id={}",
+                        count, max_allowed, self.channel_id
+                    );
+                    let mut offset = 4;
+                    for i in 0..count {
+                        if offset + 28 > payload.len() {
+                            break;
+                        }
+                        let head_id = u32::from_le_bytes([
+                            payload[offset], payload[offset+1], payload[offset+2], payload[offset+3],
+                        ]);
+                        let surface_id = u32::from_le_bytes([
+                            payload[offset+4], payload[offset+5], payload[offset+6], payload[offset+7],
+                        ]);
+                        let width = u32::from_le_bytes([
+                            payload[offset+8], payload[offset+9], payload[offset+10], payload[offset+11],
+                        ]);
+                        let height = u32::from_le_bytes([
+                            payload[offset+12], payload[offset+13], payload[offset+14], payload[offset+15],
+                        ]);
+                        let x = u32::from_le_bytes([
+                            payload[offset+16], payload[offset+17], payload[offset+18], payload[offset+19],
+                        ]);
+                        let y = u32::from_le_bytes([
+                            payload[offset+20], payload[offset+21], payload[offset+22], payload[offset+23],
+                        ]);
+                        let flags = u32::from_le_bytes([
+                            payload[offset+24], payload[offset+25], payload[offset+26], payload[offset+27],
+                        ]);
+                        info!(
+                            "display: monitors_config[{}]: head_id={}, surface_id={}, {}x{}, pos=({},{}), flags={:#x}",
+                            i, head_id, surface_id, width, height, x, y, flags
+                        );
+                        offset += 28;
+                    }
+                }
             }
 
             display_server::MARK => {
@@ -408,23 +464,53 @@ impl DisplayChannel {
                 self.send_with_log(display_client::PONG, &response).await?;
             }
 
-            display_server::INVALIDATE_LIST | display_server::INVAL_ALL_PIXMAPS => {
-                debug!("display: invalidate pixmaps received (opcode {})", msg_type);
-
-                if settings::is_verbose() {
-                    logging::log_detail(&format!(
-                        "clearing {} cached images",
-                        self.previous_images.len()
-                    ));
+            display_server::INVALIDATE_LIST => {
+                // Wire: u16 count + (u8 type + u64 id) per entry
+                if payload.len() >= 2 {
+                    let count =
+                        u16::from_le_bytes([payload[0], payload[1]]) as usize;
+                    let entry_size = 9; // u8 type + u64 id
+                    let mut removed = 0usize;
+                    for i in 0..count {
+                        let offset = 2 + i * entry_size + 1; // skip type byte
+                        if offset + 8 > payload.len() {
+                            break;
+                        }
+                        let id = u64::from_le_bytes([
+                            payload[offset],
+                            payload[offset + 1],
+                            payload[offset + 2],
+                            payload[offset + 3],
+                            payload[offset + 4],
+                            payload[offset + 5],
+                            payload[offset + 6],
+                            payload[offset + 7],
+                        ]);
+                        if self.image_cache.remove(&id).is_some() {
+                            removed += 1;
+                        }
+                    }
+                    debug!(
+                        "display: inval_list: removed {}/{} entries (cache now {})",
+                        removed,
+                        count,
+                        self.image_cache.len()
+                    );
                 }
+            }
 
-                // Clear cached images
-                self.previous_images.clear();
+            display_server::INVAL_ALL_PIXMAPS => {
+                debug!(
+                    "display: inval_all_pixmaps: clearing {} cached images",
+                    self.image_cache.len()
+                );
+                self.image_cache.clear();
             }
 
             display_server::RESET => {
                 info!("display: reset");
-                self.previous_images.clear();
+                self.image_cache.clear();
+                self.glz_dictionary.lock().unwrap().clear();
             }
 
             _ => {
@@ -443,7 +529,7 @@ impl DisplayChannel {
     }
 
     async fn handle_draw_copy(&mut self, payload: &[u8]) -> Result<()> {
-        if payload.len() < DrawCopyBase::SIZE {
+        if payload.len() < 21 {
             warn!("display: draw_copy payload too short");
             return Ok(());
         }
@@ -459,25 +545,101 @@ impl DisplayChannel {
             ));
         }
 
-        // After DrawCopyBase the SpiceCopy structure is (mini-header mode):
-        //   src_bitmap  SPICE_ADDRESS (u32)   4 bytes
-        //   src_area    SpiceRect (4 x i32)  16 bytes
-        //   rop_descriptor  u16               2 bytes
-        //   scale_mode      u8                1 byte
-        //   mask.flags      u8                1 byte
-        //   mask.pos        2 x i32           8 bytes
-        //   mask.bitmap     SPICE_ADDRESS     4 bytes
-        // Total SpiceCopy header = 36 bytes
-        // The SpiceImage (ImageDescriptor + data) follows inline.
-        let copy_header_size: usize = 4 + 16 + 2 + 1 + 1 + 8 + 4;
-        let image_start = DrawCopyBase::SIZE + copy_header_size;
+        // SpiceCopy starts with src_bitmap offset (u32) pointing to SpiceImage
+        let copy_start = base.end_offset;
+        if payload.len() < copy_start + 4 {
+            warn!("display: draw_copy: payload too short for SpiceCopy");
+            return Ok(());
+        }
 
+        let src_bitmap_offset = u32::from_le_bytes([
+            payload[copy_start],
+            payload[copy_start + 1],
+            payload[copy_start + 2],
+            payload[copy_start + 3],
+        ]) as usize;
+
+        if payload.len() < copy_start + 36 {
+            warn!("display: draw_copy: payload too short for SpiceCopy header");
+            return Ok(());
+        }
+
+        let src_top = u32::from_le_bytes([
+            payload[copy_start + 4],
+            payload[copy_start + 5],
+            payload[copy_start + 6],
+            payload[copy_start + 7],
+        ]);
+        let src_left = u32::from_le_bytes([
+            payload[copy_start + 8],
+            payload[copy_start + 9],
+            payload[copy_start + 10],
+            payload[copy_start + 11],
+        ]);
+        let src_bottom = u32::from_le_bytes([
+            payload[copy_start + 12],
+            payload[copy_start + 13],
+            payload[copy_start + 14],
+            payload[copy_start + 15],
+        ]);
+        let src_right = u32::from_le_bytes([
+            payload[copy_start + 16],
+            payload[copy_start + 17],
+            payload[copy_start + 18],
+            payload[copy_start + 19],
+        ]);
+        let rop_descriptor = u16::from_le_bytes([
+            payload[copy_start + 20],
+            payload[copy_start + 21],
+        ]);
+        let scale_mode = payload[copy_start + 22];
+        let mask_flags = payload[copy_start + 23];
+        let mask_pos_x = i32::from_le_bytes([
+            payload[copy_start + 24],
+            payload[copy_start + 25],
+            payload[copy_start + 26],
+            payload[copy_start + 27],
+        ]);
+        let mask_pos_y = i32::from_le_bytes([
+            payload[copy_start + 28],
+            payload[copy_start + 29],
+            payload[copy_start + 30],
+            payload[copy_start + 31],
+        ]);
+        let mask_bitmap_offset = u32::from_le_bytes([
+            payload[copy_start + 32],
+            payload[copy_start + 33],
+            payload[copy_start + 34],
+            payload[copy_start + 35],
+        ]) as usize;
+
+        if settings::is_verbose() {
+            debug!(
+                "display: draw_copy detail: rop={:#x}, scale_mode={}, mask_flags={:#x}, mask_pos=({},{}), mask_bitmap_offset={}, clip_type={}, clip_rects={}",
+                rop_descriptor,
+                scale_mode,
+                mask_flags,
+                mask_pos_x,
+                mask_pos_y,
+                mask_bitmap_offset,
+                base.clip_type,
+                base.clip_rects.len()
+            );
+        }
+
+        if src_bitmap_offset == 0 {
+            warn!("display: draw_copy: null src_bitmap");
+            return Ok(());
+        }
+
+        let image_start = src_bitmap_offset;
         if payload.len() < image_start + ImageDescriptor::SIZE {
             warn!(
                 "display: draw_copy: payload too short for image descriptor \
-                 (have {}, need {})",
+                 (have {}, need {}, offset={})",
                 payload.len(),
-                image_start + ImageDescriptor::SIZE
+                image_start + ImageDescriptor::SIZE,
+                src_bitmap_offset
             );
             return Ok(());
         }
@@ -485,7 +647,6 @@ impl DisplayChannel {
         let img_desc = ImageDescriptor::read(&payload[image_start..])?;
         let image_type = ImageType::from_u8(img_desc.image_type);
 
-        // Image data starts after the descriptor
         let image_data_start = image_start + ImageDescriptor::SIZE;
         if image_data_start >= payload.len() {
             warn!("display: draw_copy: no image data");
@@ -584,11 +745,15 @@ impl DisplayChannel {
                             for x in 0..width as usize {
                                 let si = x * 4;
                                 let di = dst_start + x * 4;
-                                // BGRX -> RGBA
+                                // BGRX/BGRA -> RGBA
                                 rgba[di] = src_row[si + 2]; // R
                                 rgba[di + 1] = src_row[si + 1]; // G
                                 rgba[di + 2] = src_row[si]; // B
-                                rgba[di + 3] = 255; // A
+                                rgba[di + 3] = if bmp_fmt == 9 {
+                                    src_row[si + 3]
+                                } else {
+                                    255
+                                };
                             }
                         }
                         Some(DecompressedImage {
@@ -596,7 +761,6 @@ impl DisplayChannel {
                             height,
                             pixels: rgba,
                             image_id: img_desc.image_id,
-                            win_head_dist: None,
                         })
                     }
                 }
@@ -607,7 +771,7 @@ impl DisplayChannel {
                     warn!("display: GLZ image data too short");
                     None
                 } else {
-                    match decompress_glz(&image_data[4..], &self.previous_images) {
+                    match decompress_glz(&image_data[4..], &self.glz_dictionary).await {
                         Ok(img) => Some(img),
                         Err(e) => {
                             warn!("display: GLZ decompression failed: {}", e);
@@ -655,13 +819,15 @@ impl DisplayChannel {
                     let mut decoder = ZlibDecoder::new(zlib_data);
                     let mut glz_data = Vec::new();
                     match decoder.read_to_end(&mut glz_data) {
-                        Ok(_) => match decompress_glz(&glz_data, &self.previous_images) {
-                            Ok(img) => Some(img),
-                            Err(e) => {
-                                warn!("display: ZLIB_GLZ_RGB GLZ decompression failed: {}", e);
-                                None
+                        Ok(_) => {
+                            match decompress_glz(&glz_data, &self.glz_dictionary).await {
+                                Ok(img) => Some(img),
+                                Err(e) => {
+                                    warn!("display: ZLIB_GLZ_RGB GLZ decompression failed: {}", e);
+                                    None
+                                }
                             }
-                        },
+                        }
                         Err(e) => {
                             warn!("display: ZLIB_GLZ_RGB zlib decompression failed: {}", e);
                             None
@@ -684,13 +850,12 @@ impl DisplayChannel {
             }
             Some(ImageType::FromCache) => {
                 // Look up in cache
-                if let Some(pixels) = self.previous_images.get(&img_desc.image_id) {
+                if let Some(pixels) = self.image_cache.get(&img_desc.image_id) {
                     Some(DecompressedImage {
                         width: img_desc.width,
                         height: img_desc.height,
                         pixels: pixels.clone(),
                         image_id: img_desc.image_id,
-                        win_head_dist: None,
                     })
                 } else {
                     warn!("display: image {} not in cache", img_desc.image_id);
@@ -718,11 +883,37 @@ impl DisplayChannel {
                                 height: rgba.height(),
                                 pixels: rgba.into_raw(),
                                 image_id: img_desc.image_id,
-                                win_head_dist: None,
                             })
                         }
                         Err(e) => {
                             warn!("display: JPEG decode failed: {}", e);
+                            None
+                        }
+                    }
+                }
+            }
+            Some(ImageType::Quic) => {
+                if image_data.len() < 4 {
+                    warn!("display: QUIC data too short");
+                    None
+                } else {
+                    let data_size = u32::from_le_bytes([
+                        image_data[0],
+                        image_data[1],
+                        image_data[2],
+                        image_data[3],
+                    ]) as usize;
+                    let quic_data =
+                        &image_data[4..4 + data_size.min(image_data.len() - 4)];
+                    match quic_decode(quic_data, img_desc.width, img_desc.height) {
+                        Some(rgba) => Some(DecompressedImage {
+                            width: img_desc.width,
+                            height: img_desc.height,
+                            pixels: rgba,
+                            image_id: img_desc.image_id,
+                        }),
+                        None => {
+                            warn!("display: QUIC decode failed");
                             None
                         }
                     }
@@ -757,28 +948,112 @@ impl DisplayChannel {
         }
 
         if let Some(img) = decompressed {
-            // Cache for GLZ dictionary and evict images that have
-            // fallen outside the reference window.
-            self.previous_images
-                .insert(img.image_id, img.pixels.clone());
-            if let Some(dist) = img.win_head_dist {
-                let oldest = img.image_id.saturating_sub(dist);
-                self.previous_images.retain(|&id, _| id >= oldest);
+            let is_glz = matches!(
+                image_type,
+                Some(ImageType::GlzRgb) | Some(ImageType::ZlibGlzRgb)
+            );
+            if is_glz {
+                self.glz_dictionary.lock().unwrap()
+                    .insert(img.image_id, img.pixels.clone());
+            } else {
+                self.image_cache
+                    .insert(img.image_id, img.pixels.clone());
             }
 
-            // Send to UI
-            self.event_tx
-                .send(ChannelEvent::ImageReady {
-                    surface_id: base.surface_id,
-                    left,
-                    top,
-                    width: img.width,
-                    height: img.height,
-                    pixels: img.pixels,
-                    image_id: img.image_id,
-                })
-                .await
-                .ok();
+            let mut out_width = img.width;
+            let mut out_height = img.height;
+            let mut out_pixels = img.pixels;
+
+            let crop_w = src_right.saturating_sub(src_left);
+            let crop_h = src_bottom.saturating_sub(src_top);
+            if crop_w > 0
+                && crop_h > 0
+                && (src_left != 0
+                    || src_top != 0
+                    || crop_w != out_width
+                    || crop_h != out_height)
+            {
+                let src_w = out_width as usize;
+                let src_h = out_height as usize;
+                let left_px = (src_left as usize).min(src_w);
+                let top_px = (src_top as usize).min(src_h);
+                let right_px = (src_right as usize).min(src_w);
+                let bottom_px = (src_bottom as usize).min(src_h);
+
+                if right_px > left_px && bottom_px > top_px {
+                    let new_w = right_px - left_px;
+                    let new_h = bottom_px - top_px;
+                    let mut cropped = vec![0u8; new_w * new_h * 4];
+                    for y in 0..new_h {
+                        let src_off = ((top_px + y) * src_w + left_px) * 4;
+                        let dst_off = y * new_w * 4;
+                        cropped[dst_off..dst_off + new_w * 4]
+                            .copy_from_slice(&out_pixels[src_off..src_off + new_w * 4]);
+                    }
+                    out_width = new_w as u32;
+                    out_height = new_h as u32;
+                    out_pixels = cropped;
+                }
+            }
+
+            let dest_left = left;
+            let dest_top = top;
+            let dest_right = dest_left.saturating_add(out_width);
+            let dest_bottom = dest_top.saturating_add(out_height);
+
+            if base.clip_type == 1 && !base.clip_rects.is_empty() {
+                for (clip_left, clip_top, clip_right, clip_bottom) in &base.clip_rects {
+                    let il = dest_left.max(*clip_left);
+                    let it = dest_top.max(*clip_top);
+                    let ir = dest_right.min(*clip_right);
+                    let ib = dest_bottom.min(*clip_bottom);
+                    if ir <= il || ib <= it {
+                        continue;
+                    }
+
+                    let sub_w = (ir - il) as usize;
+                    let sub_h = (ib - it) as usize;
+                    let x_off = (il - dest_left) as usize;
+                    let y_off = (it - dest_top) as usize;
+                    let out_w_usize = out_width as usize;
+                    let mut sub_pixels = vec![0u8; sub_w * sub_h * 4];
+
+                    for y in 0..sub_h {
+                        let src_off = ((y_off + y) * out_w_usize + x_off) * 4;
+                        let dst_off = y * sub_w * 4;
+                        sub_pixels[dst_off..dst_off + sub_w * 4]
+                            .copy_from_slice(&out_pixels[src_off..src_off + sub_w * 4]);
+                    }
+
+                    self.event_tx
+                        .send(ChannelEvent::ImageReady {
+                            display_channel_id: self.channel_id,
+                            surface_id: base.surface_id,
+                            left: il,
+                            top: it,
+                            width: sub_w as u32,
+                            height: sub_h as u32,
+                            pixels: sub_pixels,
+                            image_id: img.image_id,
+                        })
+                        .await
+                        .ok();
+                }
+            } else {
+                self.event_tx
+                    .send(ChannelEvent::ImageReady {
+                        display_channel_id: self.channel_id,
+                        surface_id: base.surface_id,
+                        left,
+                        top,
+                        width: out_width,
+                        height: out_height,
+                        pixels: out_pixels,
+                        image_id: img.image_id,
+                    })
+                    .await
+                    .ok();
+            }
         }
 
         Ok(())
@@ -801,10 +1076,15 @@ impl DisplayChannel {
         snap.last_ack = self.last_ack;
         snap.bytes_in = self.bytes_in;
         snap.bytes_out = self.bytes_out;
-        snap.image_cache_entries = self.previous_images.len();
-        snap.image_cache_bytes = self.previous_images.values().map(|v| v.len()).sum();
+        let glz_dict = self.glz_dictionary.lock().unwrap();
+        snap.image_cache_entries = self.image_cache.len() + glz_dict.len();
+        snap.image_cache_bytes = self.image_cache.values().map(|v| v.len()).sum::<usize>()
+            + glz_dict.values().map(|v| v.len()).sum::<usize>();
         snap.image_cache_ids = {
-            let mut ids: Vec<u64> = self.previous_images.keys().copied().collect();
+            let mut ids: Vec<u64> = self.image_cache.keys()
+                .chain(glz_dict.keys())
+                .copied()
+                .collect();
             ids.sort_unstable();
             ids
         };

--- a/src/channels/inputs.rs
+++ b/src/channels/inputs.rs
@@ -414,6 +414,13 @@ impl InputsChannel {
             }
 
             InputEvent::MouseUp { button, x, y } => {
+                // Send position before button release (as spice-gtk does)
+                let mut pos_payload = Vec::new();
+                MousePosition::write(x, y, self.button_state, 0, &mut pos_payload)?;
+                let pos_msg = make_message(inputs_client::MOUSE_POSITION, &pos_payload);
+                self.send_with_log(inputs_client::MOUSE_POSITION, &pos_msg)
+                    .await?;
+
                 self.button_state &= !button;
 
                 self.record_event(InputEventRecord {

--- a/src/channels/main_channel.rs
+++ b/src/channels/main_channel.rs
@@ -1,5 +1,6 @@
 /// Main channel handler - session management, ping/pong, channel list
 use anyhow::Result;
+use byteorder::{LittleEndian, WriteBytesExt};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
@@ -17,11 +18,26 @@ use crate::settings;
 
 use super::ChannelEvent;
 
+const VD_AGENT_PROTOCOL: u32 = 1;
+const VD_AGENT_ANNOUNCE_CAPABILITIES: u32 = 1;
+const VD_AGENT_MONITORS_CONFIG: u32 = 2;
+const VD_AGENT_CAP_MOUSE_STATE: u32 = 0;
+const VD_AGENT_CAP_MONITORS_CONFIG: u32 = 1;
+const VD_AGENT_CAP_REPLY: u32 = 2;
+const VD_AGENT_CONFIG_MONITORS_FLAG_USE_POS: u32 = 1;
+
 pub struct MainChannel {
     stream: SpiceStream,
     event_tx: mpsc::Sender<ChannelEvent>,
     buffer: Vec<u8>,
     session_id: Option<u32>,
+    agent_connected: bool,
+    agent_tokens: u32,
+    agent_caps_announced: bool,
+    monitors: u8,
+    monitors_config_rx: mpsc::Receiver<(u32, u32)>,
+    pending_monitors_config: Option<(u32, u32)>,
+    last_sent_monitors_config: Option<(u32, u32)>,
     capture: Option<Arc<CaptureSession>>,
     byte_counter: Arc<ByteCounter>,
     traffic: Arc<TrafficBuffers>,
@@ -38,12 +54,21 @@ impl MainChannel {
         byte_counter: Arc<ByteCounter>,
         traffic: Arc<TrafficBuffers>,
         snapshot: Arc<Mutex<MainSnapshot>>,
+        monitors_config_rx: mpsc::Receiver<(u32, u32)>,
+        monitors: u8,
     ) -> Self {
         MainChannel {
             stream,
             event_tx,
             buffer: Vec::with_capacity(65536),
             session_id: None,
+            agent_connected: false,
+            agent_tokens: 0,
+            agent_caps_announced: false,
+            monitors,
+            monitors_config_rx,
+            pending_monitors_config: None,
+            last_sent_monitors_config: None,
             capture,
             byte_counter,
             traffic,
@@ -62,38 +87,76 @@ impl MainChannel {
     pub async fn run(&mut self) -> Result<()> {
         info!("main: channel started");
 
+        let mut resize_debounce: Option<tokio::time::Instant> = None;
+
         loop {
-            // Read data into buffer
             let mut chunk = [0u8; 65536];
-            let n = match &mut self.stream {
-                SpiceStream::Plain(s) => {
-                    use tokio::io::AsyncReadExt;
-                    s.read(&mut chunk).await?
-                }
-                SpiceStream::Tls(s) => {
-                    use tokio::io::AsyncReadExt;
-                    s.read(&mut chunk).await?
+            let stream = &mut self.stream;
+            let monitors_config_rx = &mut self.monitors_config_rx;
+
+            let debounce_sleep = async {
+                match resize_debounce {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => std::future::pending().await,
                 }
             };
 
-            if n == 0 {
-                info!("main: channel disconnected");
-                self.event_tx
-                    .send(ChannelEvent::Disconnected(ChannelType::Main))
-                    .await
-                    .ok();
-                break;
-            }
+            tokio::select! {
+                n = async {
+                    match stream {
+                        SpiceStream::Plain(s) => {
+                            use tokio::io::AsyncReadExt;
+                            s.read(&mut chunk).await
+                        }
+                        SpiceStream::Tls(s) => {
+                            use tokio::io::AsyncReadExt;
+                            s.read(&mut chunk).await
+                        }
+                    }
+                } => {
+                    let n = n?;
+                    if n == 0 {
+                        info!("main: channel disconnected");
+                        self.event_tx
+                            .send(ChannelEvent::Disconnected(ChannelType::Main))
+                            .await
+                            .ok();
+                        break;
+                    }
 
-            self.byte_counter.add(n as u64);
-            if let Some(ref c) = self.capture {
-                c.packet_received("main", &chunk[..n]);
-            }
-            self.buffer.extend_from_slice(&chunk[..n]);
-            self.bytes_in += n as u64;
+                    self.byte_counter.add(n as u64);
+                    if let Some(ref c) = self.capture {
+                        c.packet_received("main", &chunk[..n]);
+                    }
+                    self.buffer.extend_from_slice(&chunk[..n]);
+                    self.bytes_in += n as u64;
 
-            // Process complete messages
-            self.process_messages().await?;
+                    self.process_messages().await?;
+                }
+                resize = monitors_config_rx.recv() => {
+                    let Some((width, height)) = resize else {
+                        continue;
+                    };
+
+                    if self.last_sent_monitors_config == Some((width, height)) {
+                        continue;
+                    }
+
+                    self.pending_monitors_config = Some((width, height));
+                    resize_debounce = Some(tokio::time::Instant::now() + std::time::Duration::from_millis(200));
+                }
+                _ = debounce_sleep => {
+                    resize_debounce = None;
+                    if let Some((width, height)) = self.pending_monitors_config {
+                        info!("main: resize debounced: {}x{}", width, height);
+                        self.event_tx
+                            .send(ChannelEvent::MonitorsConfig { width, height })
+                            .await
+                            .ok();
+                        self.maybe_send_agent_monitors_config().await?;
+                    }
+                }
+            }
         }
 
         Ok(())
@@ -165,6 +228,13 @@ impl MainChannel {
                 }
 
                 self.session_id = Some(init.session_id);
+                self.agent_connected = init.agent_connected != 0;
+                self.agent_tokens = init.agent_tokens;
+                self.agent_caps_announced = false;
+
+                if self.agent_connected {
+                    self.connect_agent().await?;
+                }
 
                 self.event_tx
                     .send(ChannelEvent::SessionInitialized(init.session_id))
@@ -281,6 +351,51 @@ impl MainChannel {
                     .ok();
             }
 
+            main_server::AGENT_CONNECTED => {
+                info!("main: vdagent connected");
+                self.agent_connected = true;
+                self.connect_agent().await?;
+            }
+
+            main_server::AGENT_DISCONNECTED => {
+                info!("main: vdagent disconnected");
+                self.agent_connected = false;
+                self.agent_caps_announced = false;
+            }
+
+            main_server::AGENT_DATA => {
+                if payload.len() >= 16 {
+                    let agent_type = u32::from_le_bytes([
+                        payload[4], payload[5], payload[6], payload[7],
+                    ]);
+                    let agent_size = u32::from_le_bytes([
+                        payload[12], payload[13], payload[14], payload[15],
+                    ]);
+                    debug!(
+                        "main: agent_data from server: type={}, size={}",
+                        agent_type, agent_size
+                    );
+                } else {
+                    debug!(
+                        "main: agent_data from server: {} bytes: {:02x?}",
+                        payload.len(),
+                        payload
+                    );
+                }
+            }
+
+            main_server::AGENT_TOKEN => {
+                if payload.len() >= 4 {
+                    let tokens = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+                    self.agent_tokens = self.agent_tokens.saturating_add(tokens);
+                } else {
+                    self.agent_tokens = self.agent_tokens.saturating_add(1);
+                    warn!("main: short AGENT_TOKEN payload ({} bytes)", payload.len());
+                }
+
+                self.maybe_send_announce_capabilities().await?;
+            }
+
             _ => {
                 // Unknown message - log with hex dump
                 logging::log_unknown("main", "received", msg_type, payload.len() as u32, payload);
@@ -301,6 +416,121 @@ impl MainChannel {
     async fn request_channels_list(&mut self) -> Result<()> {
         let msg = make_message(main_client::ATTACH_CHANNELS, &[]);
         self.send_with_log(main_client::ATTACH_CHANNELS, &msg).await
+    }
+
+    async fn connect_agent(&mut self) -> Result<()> {
+        self.send_agent_start().await?;
+        self.maybe_send_announce_capabilities().await
+    }
+
+    async fn send_agent_start(&mut self) -> Result<()> {
+        let mut payload = Vec::with_capacity(4);
+        payload.write_u32::<LittleEndian>(u32::MAX)?;
+        let msg = make_message(main_client::AGENT_START, &payload);
+        self.send_with_log(main_client::AGENT_START, &msg).await
+    }
+
+    async fn maybe_send_announce_capabilities(&mut self) -> Result<()> {
+        if !self.agent_connected || self.agent_caps_announced {
+            return Ok(());
+        }
+
+        let caps = (1u32 << VD_AGENT_CAP_MOUSE_STATE)
+            | (1u32 << VD_AGENT_CAP_MONITORS_CONFIG)
+            | (1u32 << VD_AGENT_CAP_REPLY);
+        let mut payload = Vec::with_capacity(8);
+        payload.write_u32::<LittleEndian>(1)?;
+        payload.write_u32::<LittleEndian>(caps)?;
+
+        if self.send_agent_data_message(VD_AGENT_ANNOUNCE_CAPABILITIES, &payload).await? {
+            self.agent_caps_announced = true;
+        }
+
+        Ok(())
+    }
+
+    async fn maybe_send_agent_monitors_config(&mut self) -> Result<()> {
+
+        let Some((width, height)) = self.pending_monitors_config else {
+            debug!("main: monitors config: no pending config");
+            return Ok(());
+        };
+
+        if !self.agent_connected {
+            debug!("main: monitors config: agent not connected");
+            return Ok(());
+        }
+
+        if !self.agent_caps_announced {
+            debug!("main: monitors config: caps not announced yet");
+            return Ok(());
+        }
+
+        if self.last_sent_monitors_config == Some((width, height)) {
+            return Ok(());
+        }
+
+        info!("main: sending monitors config: {}x{}", width, height);
+        if self.send_agent_monitors_config(width, height).await? {
+            self.last_sent_monitors_config = Some((width, height));
+            self.pending_monitors_config = None;
+        } else {
+            debug!("main: monitors config: no agent tokens");
+        }
+
+        Ok(())
+    }
+
+    async fn send_agent_monitors_config(&mut self, width: u32, height: u32) -> Result<bool> {
+        let active = if self.monitors == 0 { 1 } else { self.monitors as u32 };
+        let flags = if active > 1 { VD_AGENT_CONFIG_MONITORS_FLAG_USE_POS } else { 0 };
+
+        let mut payload = Vec::with_capacity(8 + active as usize * 20);
+        payload.write_u32::<LittleEndian>(active)?;
+        payload.write_u32::<LittleEndian>(flags)?;
+
+        for i in 0..active {
+            info!(
+                "main: monitors config[{}]: {}x{} pos=({},0) depth=32",
+                i, width, height, width * i
+            );
+            payload.write_u32::<LittleEndian>(height)?;
+            payload.write_u32::<LittleEndian>(width)?;
+            payload.write_u32::<LittleEndian>(32)?;
+            if active > 1 {
+                payload.write_u32::<LittleEndian>(width * i)?;
+            } else {
+                payload.write_u32::<LittleEndian>(0)?;
+            }
+            payload.write_u32::<LittleEndian>(0)?;
+        }
+
+        info!("main: agent monitors config: num_mon={}, flags={}", active, flags);
+
+        debug!("main: monitors config payload ({} bytes): {:02x?}", payload.len(), payload);
+
+        self.send_agent_data_message(VD_AGENT_MONITORS_CONFIG, &payload)
+            .await
+    }
+
+    async fn send_agent_data_message(&mut self, ty: u32, payload: &[u8]) -> Result<bool> {
+        if self.agent_tokens == 0 {
+            return Ok(false);
+        }
+
+        let mut agent = Vec::with_capacity(16 + payload.len());
+        agent.write_u32::<LittleEndian>(VD_AGENT_PROTOCOL)?;
+        agent.write_u32::<LittleEndian>(ty)?;
+        agent.write_u64::<LittleEndian>(0)?;
+        agent.write_u32::<LittleEndian>(payload.len() as u32)?;
+        agent.extend_from_slice(payload);
+
+        debug!("main: agent_data wrapper ({} bytes): {:02x?}", agent.len(), agent);
+        let msg = make_message(main_client::AGENT_DATA, &agent);
+        self.send_with_log(main_client::AGENT_DATA, &msg).await?;
+        self.agent_tokens = self.agent_tokens.saturating_sub(1);
+
+        Ok(true)
     }
 
     async fn send_with_log(&mut self, msg_type: u16, data: &[u8]) -> Result<()> {

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -28,16 +28,21 @@ pub enum ChannelEvent {
 
     /// Surface created
     SurfaceCreated {
+        display_channel_id: u8,
         surface_id: u32,
         width: u32,
         height: u32,
     },
 
     /// Surface destroyed
-    SurfaceDestroyed { surface_id: u32 },
+    SurfaceDestroyed {
+        display_channel_id: u8,
+        surface_id: u32,
+    },
 
     /// Image data ready to display
     ImageReady {
+        display_channel_id: u8,
         surface_id: u32,
         left: u32,
         top: u32,
@@ -59,6 +64,8 @@ pub enum ChannelEvent {
 
     /// Mouse mode from server (1=server, 2=client)
     MouseMode(u32),
+
+    MonitorsConfig { width: u32, height: u32 },
 
     /// Statistics update (reserved for future use)
     #[allow(dead_code)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,10 @@ pub struct Args {
     #[arg(long)]
     pub capture: Option<String>,
 
+    /// Number of monitors to connect (default: 1)
+    #[arg(long, default_value_t = 1)]
+    pub monitors: u8,
+
     /// Present a RAW disk image as a USB mass storage device (repeatable)
     #[arg(long = "usb-disk")]
     pub usb_disk: Vec<String>,

--- a/src/decompression/glz.rs
+++ b/src/decompression/glz.rs
@@ -7,23 +7,18 @@ use anyhow::{anyhow, Result};
 use byteorder::{BigEndian, ReadBytesExt};
 use std::collections::HashMap;
 use std::io::{Cursor, Read};
+use std::sync::{Arc, Mutex};
 
 use super::DecompressedImage;
 
 const GLZ_MAGIC: &[u8; 4] = b"  ZL";
 const LZ_MAX_COPY: u8 = 32;
+const CROSS_REF_MAX_RETRIES: u32 = 20;
+const CROSS_REF_RETRY_MS: u64 = 5;
 
-/// Decompress GLZ image data
-///
-/// # Arguments
-/// * `data` - The compressed GLZ data
-/// * `previous_images` - Dictionary of previously decompressed images for cross-frame refs
-///
-/// # Returns
-/// * `DecompressedImage` with RGBA pixels
-pub fn decompress_glz(
+pub async fn decompress_glz(
     data: &[u8],
-    previous_images: &HashMap<u64, Vec<u8>>,
+    previous_images: &Arc<Mutex<HashMap<u64, Vec<u8>>>>,
 ) -> Result<DecompressedImage> {
     if data.len() < 33 {
         return Err(anyhow!("GLZ data too short for header"));
@@ -57,7 +52,7 @@ pub fn decompress_glz(
 
     let type_packed = cursor.read_u8()?;
     let _img_type = type_packed & 0x0F;
-    let _top_down = (type_packed >> 4) & 0x01;
+    let top_down = (type_packed >> 4) & 0x01 != 0;
 
     let width = cursor.read_u32::<BigEndian>()?;
     let height = cursor.read_u32::<BigEndian>()?;
@@ -66,11 +61,12 @@ pub fn decompress_glz(
     let win_head_dist = cursor.read_u32::<BigEndian>()?;
 
     tracing::debug!(
-        "glz: header id={}, {}x{}, type={}, win_head_dist={}",
+        "glz: header id={}, {}x{}, type={}, top_down={}, win_head_dist={}",
         image_id,
         width,
         height,
         _img_type,
+        top_down,
         win_head_dist
     );
 
@@ -213,25 +209,36 @@ pub fn decompress_glz(
             } else {
                 // Copy from a previous image in the dictionary
                 let source_id = image_id.wrapping_sub(image_dist);
-                if let Some(prev_img) = previous_images.get(&source_id) {
-                    let mut pi_idx = pixel_offset * 4;
-                    for _ in 0..length {
-                        if out_idx + 4 > output_size || pi_idx + 4 > prev_img.len() {
-                            break;
-                        }
-                        output[out_idx] = prev_img[pi_idx];
-                        output[out_idx + 1] = prev_img[pi_idx + 1];
-                        output[out_idx + 2] = prev_img[pi_idx + 2];
-                        output[out_idx + 3] = prev_img[pi_idx + 3];
-                        out_idx += 4;
-                        pi_idx += 4;
+
+                let mut found = false;
+                for attempt in 0..=CROSS_REF_MAX_RETRIES {
+                    if attempt > 0 {
+                        tokio::time::sleep(tokio::time::Duration::from_millis(CROSS_REF_RETRY_MS)).await;
                     }
-                } else {
-                    // Image not in dictionary -- leave pixels black
+                    let dict = previous_images.lock().unwrap();
+                    if let Some(prev_img) = dict.get(&source_id) {
+                        let mut pi_idx = pixel_offset * 4;
+                        for _ in 0..length {
+                            if out_idx + 4 > output_size || pi_idx + 4 > prev_img.len() {
+                                break;
+                            }
+                            output[out_idx] = prev_img[pi_idx];
+                            output[out_idx + 1] = prev_img[pi_idx + 1];
+                            output[out_idx + 2] = prev_img[pi_idx + 2];
+                            output[out_idx + 3] = prev_img[pi_idx + 3];
+                            out_idx += 4;
+                            pi_idx += 4;
+                        }
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
                     tracing::warn!(
                         "glz: cross-image ref to id {} not in dictionary \
-                         (current={}, dist={})",
+                         after {} retries (current={}, dist={})",
                         source_id,
+                        CROSS_REF_MAX_RETRIES,
                         image_id,
                         image_dist
                     );
@@ -241,12 +248,22 @@ pub fn decompress_glz(
         }
     }
 
+    if !top_down {
+        let row_bytes = width as usize * 4;
+        let mut flipped = vec![0u8; output.len()];
+        for y in 0..height as usize {
+            let src = y * row_bytes;
+            let dst = (height as usize - 1 - y) * row_bytes;
+            flipped[dst..dst + row_bytes].copy_from_slice(&output[src..src + row_bytes]);
+        }
+        output = flipped;
+    }
+
     Ok(DecompressedImage {
         width,
         height,
         pixels: output,
         image_id,
-        win_head_dist: Some(win_head_dist as u64),
     })
 }
 
@@ -275,7 +292,9 @@ mod tests {
             header.extend_from_slice(&[0, 128, 255]); // BGR
         }
 
-        let result = decompress_glz(&header, &HashMap::new());
+        let dict = Arc::new(Mutex::new(HashMap::new()));
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(decompress_glz(&header, &dict));
         assert!(result.is_ok());
 
         let img = result.unwrap();

--- a/src/decompression/lz.rs
+++ b/src/decompression/lz.rs
@@ -57,7 +57,7 @@ pub fn decompress_lz(data: &[u8]) -> Result<DecompressedImage> {
     let width = cursor.read_u32::<BigEndian>()?;
     let height = cursor.read_u32::<BigEndian>()?;
     let _stride = cursor.read_u32::<BigEndian>()?;
-    let _top_down = cursor.read_u32::<BigEndian>()?;
+    let top_down = cursor.read_u32::<BigEndian>()? != 0;
 
     // Output buffer (RGBA)
     let output_size = (width as usize)
@@ -163,12 +163,22 @@ pub fn decompress_lz(data: &[u8]) -> Result<DecompressedImage> {
         }
     }
 
+    if !top_down {
+        let row_bytes = width as usize * 4;
+        let mut flipped = vec![0u8; output.len()];
+        for y in 0..height as usize {
+            let src = y * row_bytes;
+            let dst = (height as usize - 1 - y) * row_bytes;
+            flipped[dst..dst + row_bytes].copy_from_slice(&output[src..src + row_bytes]);
+        }
+        output = flipped;
+    }
+
     Ok(DecompressedImage {
         width,
         height,
         pixels: output,
-        image_id: 0, // LZ doesn't use image IDs
-        win_head_dist: None,
+        image_id: 0,
     })
 }
 

--- a/src/decompression/mod.rs
+++ b/src/decompression/mod.rs
@@ -1,15 +1,16 @@
 pub mod glz;
 pub mod lz;
+pub mod quic;
 
 pub use glz::decompress_glz;
 pub use lz::decompress_lz;
+pub use quic::quic_decode;
 
 /// Result of decompression
 #[derive(Debug)]
 pub struct DecompressedImage {
     pub width: u32,
     pub height: u32,
-    pub pixels: Vec<u8>,            // RGBA format
-    pub image_id: u64,              // For GLZ dictionary
-    pub win_head_dist: Option<u64>, // GLZ window distance (for eviction)
+    pub pixels: Vec<u8>,
+    pub image_id: u64,
 }

--- a/src/decompression/quic.rs
+++ b/src/decompression/quic.rs
@@ -1,0 +1,1527 @@
+#![allow(dead_code, clippy::needless_range_loop)]
+
+use tracing::{debug, warn};
+
+const QUIC_IMAGE_TYPE_INVALID: u32 = 0;
+const QUIC_IMAGE_TYPE_GRAY: u32 = 1;
+const QUIC_IMAGE_TYPE_RGB16: u32 = 2;
+const QUIC_IMAGE_TYPE_RGB24: u32 = 3;
+const QUIC_IMAGE_TYPE_RGB32: u32 = 4;
+const QUIC_IMAGE_TYPE_RGBA: u32 = 5;
+
+const DEFEVOL: usize = 3;
+const DEFWMIMAX: u32 = 6;
+const DEFWMINEXT: u32 = 2048;
+const DEFMAXCLEN: usize = 26;
+
+const RGB32_PIXEL_PAD: usize = 3;
+const RGB32_PIXEL_R: usize = 2;
+const RGB32_PIXEL_G: usize = 1;
+const RGB32_PIXEL_B: usize = 0;
+const RGB32_PIXEL_SIZE: usize = 4;
+
+const BPPMASK: [u32; 33] = [
+    0x00000000, 0x00000001, 0x00000003, 0x00000007, 0x0000000f, 0x0000001f, 0x0000003f,
+    0x0000007f, 0x000000ff, 0x000001ff, 0x000003ff, 0x000007ff, 0x00000fff, 0x00001fff,
+    0x00003fff, 0x00007fff, 0x0000ffff, 0x0001ffff, 0x0003ffff, 0x0007ffff, 0x000fffff,
+    0x001fffff, 0x003fffff, 0x007fffff, 0x00ffffff, 0x01ffffff, 0x03ffffff, 0x07ffffff,
+    0x0fffffff, 0x1fffffff, 0x3fffffff, 0x7fffffff, 0xffffffff,
+];
+
+const BESTTRIGTAB: [[u32; 11]; 3] = [
+    [550, 900, 800, 700, 500, 350, 300, 200, 180, 180, 160],
+    [110, 550, 900, 800, 550, 400, 350, 250, 140, 160, 140],
+    [100, 120, 550, 900, 700, 500, 400, 300, 220, 250, 160],
+];
+
+const J: [u8; 32] = [
+    0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 9, 10, 11,
+    12, 13, 14, 15,
+];
+
+const LZEROES: [u8; 256] = [
+    8, 7, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4,
+    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+];
+
+const TABRAND_CHAOS: [u32; 256] = [
+    0x02c57542, 0x35427717, 0x2f5a2153, 0x9244f155, 0x7bd26d07, 0x354c6052, 0x57329b28,
+    0x2993868e, 0x6cd8808c, 0x147b46e0, 0x99db66af, 0xe32b4cac, 0x1b671264, 0x9d433486,
+    0x62a4c192, 0x06089a4b, 0x9e3dce44, 0xdaabee13, 0x222425ea, 0xa46f331d, 0xcd589250,
+    0x8bb81d7f, 0xc8b736b9, 0x35948d33, 0xd7ac7fd0, 0x5fbe2803, 0x2cfbc105, 0x013dbc4e,
+    0x7a37820f, 0x39f88e9e, 0xedd58794, 0xc5076689, 0xfcada5a4, 0x64c2f46d, 0xb3ba3243,
+    0x8974b4f9, 0x5a05aebd, 0x20afcd00, 0x39e2b008, 0x88a18a45, 0x600bde29, 0xf3971ace,
+    0xf37b0a6b, 0x7041495b, 0x70b707ab, 0x06beffbb, 0x4206051f, 0xe13c4ee3, 0xc1a78327,
+    0x91aa067c, 0x8295f72a, 0x732917a6, 0x1d871b4d, 0x4048f136, 0xf1840e7e, 0x6a6048c1,
+    0x696cb71a, 0x7ff501c3, 0x0fc6310b, 0x57e0f83d, 0x8cc26e74, 0x11a525a2, 0x946934c7,
+    0x7cd888f0, 0x8f9d8604, 0x4f86e73b, 0x04520316, 0xdeeea20c, 0xf1def496, 0x67687288,
+    0xf540c5b2, 0x22401484, 0x3478658a, 0xc2385746, 0x01979c2c, 0x5dad73c8, 0x0321f58b,
+    0xf0fedbee, 0x92826ddf, 0x284bec73, 0x5b1a1975, 0x03df1e11, 0x20963e01, 0xa17cf12b,
+    0x740d776e, 0xa7a6bf3c, 0x01b5cce4, 0x1118aa76, 0xfc6fac0a, 0xce927e9b, 0x00bf2567,
+    0x806f216c, 0xbca69056, 0x795bd3e9, 0xc9dc4557, 0x8929b6c2, 0x789d52ec, 0x3f3fbf40,
+    0xb9197368, 0xa38c15b5, 0xc3b44fa8, 0xca8333b0, 0xb7e8d590, 0xbe807feb, 0xbf5f8360,
+    0xd99e2f5c, 0x372928e1, 0x7c757c4c, 0x0db5b154, 0xc01ede02, 0x1fc86e78, 0x1f3985be,
+    0xb4805c77, 0x00c880fa, 0x974c1b12, 0x35ab0214, 0xb2dc840d, 0x5b00ae37, 0xd313b026,
+    0xb260969d, 0x7f4c8879, 0x1734c4d3, 0x49068631, 0xb9f6a021, 0x6b863e6f, 0xcee5debf,
+    0x29f8c9fb, 0x53dd6880, 0x72b61223, 0x1f67a9fd, 0x0a0f6993, 0x13e59119, 0x11cca12e,
+    0xfe6b6766, 0x16b6effc, 0x97918fc4, 0xc2b8a563, 0x94f2f741, 0x0bfa8c9a, 0xd1537ae8,
+    0xc1da349c, 0x873c60ca, 0x95005b85, 0x9b5c080e, 0xbc8abbd9, 0xe1eab1d2, 0x6dac9070,
+    0x4ea9ebf1, 0xe0cf30d4, 0x1ef5bd7b, 0xd161043e, 0x5d2fa2e2, 0xff5d3cae, 0x86ed9f87,
+    0x2aa1daa1, 0xbd731a34, 0x9e8f4b22, 0xb1c2c67a, 0xc21758c9, 0xa182215d, 0xccb01948,
+    0x8d168df7, 0x04238cfe, 0x368c3dbc, 0x0aeadca5, 0xbad21c24, 0x0a71fee5, 0x9fc5d872,
+    0x54c152c6, 0xfc329483, 0x6783384a, 0xeddb3e1c, 0x65f90e30, 0x884ad098, 0xce81675a,
+    0x4b372f7d, 0x68bf9a39, 0x43445f1e, 0x40f8d8cb, 0x90d5acb6, 0x4cd07282, 0x349eeb06,
+    0x0c9d5332, 0x520b24ef, 0x80020447, 0x67976491, 0x2f931ca3, 0xfe9b0535, 0xfcd30220,
+    0x61a9e6cc, 0xa487d8d7, 0x3f7c5dd1, 0x7d0127c5, 0x48f51d15, 0x60dea871, 0xc9a91cb7,
+    0x58b53bb3, 0x9d5e0b2d, 0x624a78b4, 0x30dbee1b, 0x9bdf22e7, 0x1df5c299, 0x2d5643a7,
+    0xf4dd35ff, 0x03ca8fd6, 0x53b47ed8, 0x6f2c19aa, 0xfeb0c1f4, 0x49e54438, 0x2f2577e6,
+    0xbf876969, 0x72440ea9, 0xfa0bafb8, 0x74f5b3a0, 0x7dd357cd, 0x89ce1358, 0x6ef2cdda,
+    0x1e7767f3, 0xa6be9fdb, 0x4f5f88f8, 0xba994a3a, 0x08ca6b65, 0xe0893818, 0x9e00a16a,
+    0xf42bfc8f, 0x9972eedc, 0x749c8b51, 0x32c05f5e, 0xd706805f, 0x6bfbb7cf, 0xd9210a10,
+    0x31a1db97, 0x923a9559, 0x37a7a1f6, 0x059f8861, 0xca493e62, 0x65157e81, 0x8f6467dd,
+    0xab85ff9f, 0x9331aff2, 0x8616b9f5, 0xedbd5695, 0xee7e29b1, 0x313ac44f, 0xb903112f,
+    0x432ef649, 0xdc0a36c0, 0x61cf2bba, 0x81474925, 0xa8b6c7ad, 0xee5931de, 0xb2f8158d,
+    0x59fb7409, 0x2e3dfaed, 0x9af25a3f, 0xe1fed4d5,
+];
+
+#[derive(Clone)]
+struct Family {
+    n_gr_codewords: [u32; 8],
+    not_gr_cw_len: [u32; 8],
+    not_gr_prefix_mask: [u32; 8],
+    not_gr_suffix_len: [u32; 8],
+    xlat_u2l: Vec<u32>,
+    xlat_l2u: Vec<u32>,
+}
+
+impl Family {
+    fn new() -> Self {
+        Self {
+            n_gr_codewords: [0; 8],
+            not_gr_cw_len: [0; 8],
+            not_gr_prefix_mask: [0; 8],
+            not_gr_suffix_len: [0; 8],
+            xlat_u2l: Vec::new(),
+            xlat_l2u: Vec::new(),
+        }
+    }
+}
+
+fn ceil_log_2(mut val: u32) -> u32 {
+    if val == 1 {
+        return 0;
+    }
+    let mut result = 1;
+    val -= 1;
+    while val != 0 {
+        val >>= 1;
+        if val != 0 {
+            result += 1;
+        }
+    }
+    result
+}
+
+fn family_init(family: &mut Family, bpc: usize, limit: usize) {
+    for l in 0..bpc {
+        let mut altprefixlen = (limit - bpc) as u32;
+        if altprefixlen > BPPMASK[bpc - l] {
+            altprefixlen = BPPMASK[bpc - l];
+        }
+
+        let altcodewords = BPPMASK[bpc] + 1 - (altprefixlen << l);
+        family.n_gr_codewords[l] = altprefixlen << l;
+        family.not_gr_cw_len[l] = altprefixlen + ceil_log_2(altcodewords);
+        family.not_gr_prefix_mask[l] = BPPMASK[32 - altprefixlen as usize];
+        family.not_gr_suffix_len[l] = ceil_log_2(altcodewords);
+    }
+
+    let pixelbitmask = BPPMASK[bpc];
+    let pixelbitmaskshr = pixelbitmask >> 1;
+    family.xlat_u2l.resize((pixelbitmask + 1) as usize, 0);
+    family.xlat_l2u.resize((pixelbitmask + 1) as usize, 0);
+
+    for s in 0..=pixelbitmask {
+        family.xlat_u2l[s as usize] = if s <= pixelbitmaskshr {
+            s << 1
+        } else {
+            ((pixelbitmask - s) << 1) + 1
+        };
+    }
+
+    for s in 0..=pixelbitmask {
+        family.xlat_l2u[s as usize] = if s & 0x1 == 1 {
+            pixelbitmask - (s >> 1)
+        } else {
+            s >> 1
+        };
+    }
+}
+
+fn quic_image_bpc(image_type: u32) -> u32 {
+    match image_type {
+        QUIC_IMAGE_TYPE_GRAY => 8,
+        QUIC_IMAGE_TYPE_RGB16 => 5,
+        QUIC_IMAGE_TYPE_RGB24 | QUIC_IMAGE_TYPE_RGB32 | QUIC_IMAGE_TYPE_RGBA => 8,
+        _ => 0,
+    }
+}
+
+fn cnt_l_zeroes(bits: u32) -> u32 {
+    if bits & 0xff80_0000 != 0 {
+        LZEROES[(bits >> 24) as usize] as u32
+    } else if bits & 0xffff_8000 != 0 {
+        8 + LZEROES[((bits >> 16) & 0xff) as usize] as u32
+    } else if bits & 0xffff_ff80 != 0 {
+        16 + LZEROES[((bits >> 8) & 0xff) as usize] as u32
+    } else {
+        24 + LZEROES[(bits & 0xff) as usize] as u32
+    }
+}
+
+fn golomb_decoding_8bpc(l: usize, bits: u32, family_8bpc: &Family) -> (u32, u32) {
+    if (bits as i32) < 0 || bits > family_8bpc.not_gr_prefix_mask[l] {
+        let zeroprefix = cnt_l_zeroes(bits);
+        let cwlen = zeroprefix + 1 + l as u32;
+        let rc = (zeroprefix << l) | ((bits >> (32 - cwlen)) & BPPMASK[l]);
+        (cwlen, rc)
+    } else {
+        let cwlen = family_8bpc.not_gr_cw_len[l];
+        let rc = family_8bpc.n_gr_codewords[l]
+            + ((bits >> (32 - cwlen)) & BPPMASK[family_8bpc.not_gr_suffix_len[l] as usize]);
+        (cwlen, rc)
+    }
+}
+
+fn golomb_code_len_8bpc(n: u32, l: usize, family_8bpc: &Family) -> u32 {
+    if n < family_8bpc.n_gr_codewords[l] {
+        (n >> l) + 1 + l as u32
+    } else {
+        family_8bpc.not_gr_cw_len[l]
+    }
+}
+
+#[derive(Clone)]
+struct QuicModel {
+    n_buckets: usize,
+    repfirst: u32,
+    firstsize: u32,
+    repnext: u32,
+    mulsize: u32,
+    levels: u32,
+}
+
+impl QuicModel {
+    fn new(bpc: u32) -> Self {
+        let levels = 1u32 << bpc;
+        let (repfirst, firstsize, repnext, mulsize) = match DEFEVOL {
+            1 => (3, 1, 2, 2),
+            3 => (1, 1, 1, 2),
+            5 => (1, 1, 1, 4),
+            _ => (1, 1, 1, 2),
+        };
+
+        let mut n_buckets = 0usize;
+        let mut repcntr = repfirst + 1;
+        let mut bsize = firstsize;
+        let mut bend = 0u32;
+
+        loop {
+            let bstart = if n_buckets > 0 { bend + 1 } else { 0 };
+            repcntr -= 1;
+            if repcntr == 0 {
+                repcntr = repnext;
+                bsize *= mulsize;
+            }
+
+            bend = bstart + bsize - 1;
+            if bend + bsize >= levels {
+                bend = levels - 1;
+            }
+            n_buckets += 1;
+            if bend >= levels - 1 {
+                break;
+            }
+        }
+
+        Self {
+            n_buckets,
+            repfirst,
+            firstsize,
+            repnext,
+            mulsize,
+            levels,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct QuicBucket {
+    bestcode: usize,
+    counters: [u32; 8],
+}
+
+impl QuicBucket {
+    fn new() -> Self {
+        Self {
+            bestcode: 0,
+            counters: [0; 8],
+        }
+    }
+
+    fn reset(&mut self, bpp: usize) {
+        self.bestcode = bpp;
+        self.counters = [0; 8];
+    }
+
+    fn update_model_8bpc(&mut self, state: &mut CommonState, curval: u32, bpp: usize, family_8bpc: &Family) {
+        let mut bestcode = bpp - 1;
+        self.counters[bestcode] = self.counters[bestcode]
+            .saturating_add(golomb_code_len_8bpc(curval, bestcode, family_8bpc));
+        let mut bestcodelen = self.counters[bestcode];
+
+        for i in (0..=(bpp - 2)).rev() {
+            self.counters[i] = self.counters[i].saturating_add(golomb_code_len_8bpc(curval, i, family_8bpc));
+            if self.counters[i] < bestcodelen {
+                bestcode = i;
+                bestcodelen = self.counters[i];
+            }
+        }
+
+        self.bestcode = bestcode;
+        if bestcodelen > state.wm_trigger {
+            for i in 0..bpp {
+                self.counters[i] >>= 1;
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct QuicFamilyStat {
+    buckets_ptrs: Vec<usize>,
+    n_buckets: usize,
+}
+
+impl QuicFamilyStat {
+    fn new() -> Self {
+        Self {
+            buckets_ptrs: Vec::new(),
+            n_buckets: 0,
+        }
+    }
+
+    fn fill_model_structures(&mut self, model: &QuicModel) {
+        let mut bend = 0u32;
+        let mut bnumber = 0usize;
+        let mut repcntr = model.repfirst + 1;
+        let mut bsize = model.firstsize;
+
+        self.buckets_ptrs.resize(model.levels as usize, 0);
+
+        loop {
+            let bstart = if bnumber > 0 { bend + 1 } else { 0 };
+            repcntr -= 1;
+            if repcntr == 0 {
+                repcntr = model.repnext;
+                bsize *= model.mulsize;
+            }
+
+            bend = bstart + bsize - 1;
+            if bend + bsize >= model.levels {
+                bend = model.levels - 1;
+            }
+
+            for i in bstart..=bend {
+                self.buckets_ptrs[i as usize] = bnumber;
+            }
+            bnumber += 1;
+
+            if bend >= model.levels - 1 {
+                break;
+            }
+        }
+
+        self.n_buckets = bnumber;
+    }
+}
+
+#[derive(Clone)]
+struct CorrelateRow {
+    zero: u32,
+    row: Vec<u32>,
+}
+
+#[derive(Clone)]
+struct CommonState {
+    waitcnt: usize,
+    tabrand_seed: u32,
+    wm_trigger: u32,
+    wmidx: usize,
+    wmileft: usize,
+    melcstate: usize,
+    melclen: usize,
+    melcorder: usize,
+}
+
+impl CommonState {
+    fn new() -> Self {
+        let mut s = Self {
+            waitcnt: 0,
+            tabrand_seed: 0xff,
+            wm_trigger: 0,
+            wmidx: 0,
+            wmileft: DEFWMINEXT as usize,
+            melcstate: 0,
+            melclen: 0,
+            melcorder: 1,
+        };
+        s.reset();
+        s
+    }
+
+    fn set_wm_trigger(&mut self) {
+        let wm = self.wmidx.min(10);
+        self.wm_trigger = BESTTRIGTAB[DEFEVOL / 2][wm];
+    }
+
+    fn reset(&mut self) {
+        self.waitcnt = 0;
+        self.tabrand_seed = 0x0ff;
+        self.wmidx = 0;
+        self.wmileft = DEFWMINEXT as usize;
+        self.set_wm_trigger();
+        self.melcstate = 0;
+        self.melclen = J[0] as usize;
+        self.melcorder = 1 << self.melclen;
+    }
+
+    fn tabrand(&mut self) -> u32 {
+        self.tabrand_seed = self.tabrand_seed.wrapping_add(1);
+        TABRAND_CHAOS[(self.tabrand_seed & 0xff) as usize]
+    }
+}
+
+#[derive(Clone)]
+struct QuicChannel {
+    state: CommonState,
+    family_stat_8bpc: QuicFamilyStat,
+    family_stat_5bpc: QuicFamilyStat,
+    correlate_row: CorrelateRow,
+    buckets_ptrs: Vec<usize>,
+    buckets_buf: Vec<QuicBucket>,
+}
+
+impl QuicChannel {
+    fn new(model_8bpc: &QuicModel, model_5bpc: &QuicModel) -> Self {
+        let mut family_stat_8bpc = QuicFamilyStat::new();
+        family_stat_8bpc.fill_model_structures(model_8bpc);
+
+        let mut family_stat_5bpc = QuicFamilyStat::new();
+        family_stat_5bpc.fill_model_structures(model_5bpc);
+
+        Self {
+            state: CommonState::new(),
+            family_stat_8bpc,
+            family_stat_5bpc,
+            correlate_row: CorrelateRow {
+                zero: 0,
+                row: Vec::new(),
+            },
+            buckets_ptrs: Vec::new(),
+            buckets_buf: Vec::new(),
+        }
+    }
+
+    fn reset(&mut self, bpc: u32, width: usize) -> bool {
+        self.correlate_row.zero = 0;
+        self.correlate_row.row.clear();
+        self.correlate_row.row.resize(width, 0);
+
+        match bpc {
+            8 => {
+                self.buckets_ptrs = self.family_stat_8bpc.buckets_ptrs.clone();
+                self.buckets_buf = vec![QuicBucket::new(); self.family_stat_8bpc.n_buckets];
+                for b in &mut self.buckets_buf {
+                    b.reset(7);
+                }
+            }
+            5 => {
+                self.buckets_ptrs = self.family_stat_5bpc.buckets_ptrs.clone();
+                self.buckets_buf = vec![QuicBucket::new(); self.family_stat_5bpc.n_buckets];
+                for b in &mut self.buckets_buf {
+                    b.reset(4);
+                }
+            }
+            _ => return false,
+        }
+
+        self.state.reset();
+        true
+    }
+}
+
+struct QuicDecoder {
+    image_type: u32,
+    width: usize,
+    height: usize,
+    io_idx: usize,
+    io_available_bits: u32,
+    io_word: u32,
+    io_next_word: u32,
+    io_now: Vec<u8>,
+    io_end: usize,
+    rows_completed: usize,
+    rgb_state: CommonState,
+    channels: [QuicChannel; 4],
+    model_8bpc: QuicModel,
+    family_8bpc: Family,
+    zero_lut: [u8; 256],
+}
+
+impl QuicDecoder {
+    fn new() -> Self {
+        let mut family_8bpc = Family::new();
+        family_init(&mut family_8bpc, 8, DEFMAXCLEN);
+
+        let mut _family_5bpc = Family::new();
+        family_init(&mut _family_5bpc, 5, DEFMAXCLEN);
+
+        let model_8bpc = QuicModel::new(8);
+        let model_5bpc = QuicModel::new(5);
+
+        let mut zero_lut = [0u8; 256];
+        let mut j = 1usize;
+        let mut k = 1usize;
+        let mut l = 8u8;
+        for slot in &mut zero_lut {
+            *slot = l;
+            k -= 1;
+            if k == 0 {
+                k = j;
+                l = l.saturating_sub(1);
+                j *= 2;
+            }
+        }
+
+        Self {
+            image_type: QUIC_IMAGE_TYPE_INVALID,
+            width: 0,
+            height: 0,
+            io_idx: 0,
+            io_available_bits: 0,
+            io_word: 0,
+            io_next_word: 0,
+            io_now: Vec::new(),
+            io_end: 0,
+            rows_completed: 0,
+            rgb_state: CommonState::new(),
+            channels: [
+                QuicChannel::new(&model_8bpc, &model_5bpc),
+                QuicChannel::new(&model_8bpc, &model_5bpc),
+                QuicChannel::new(&model_8bpc, &model_5bpc),
+                QuicChannel::new(&model_8bpc, &model_5bpc),
+            ],
+            model_8bpc,
+            family_8bpc,
+            zero_lut,
+        }
+    }
+
+    fn reset(&mut self, io_ptr: &[u8]) {
+        self.rgb_state.reset();
+        self.io_now.clear();
+        self.io_now.extend_from_slice(io_ptr);
+        self.io_end = self.io_now.len();
+        self.io_idx = 0;
+        self.rows_completed = 0;
+    }
+
+    fn read_io_word(&mut self) -> bool {
+        if self.io_idx + 4 > self.io_end {
+            return false;
+        }
+        self.io_next_word = (self.io_now[self.io_idx] as u32)
+            | ((self.io_now[self.io_idx + 1] as u32) << 8)
+            | ((self.io_now[self.io_idx + 2] as u32) << 16)
+            | ((self.io_now[self.io_idx + 3] as u32) << 24);
+        self.io_idx += 4;
+        true
+    }
+
+    fn decode_eatbits(&mut self, len: u32) -> bool {
+        self.io_word <<= len;
+        let delta = self.io_available_bits as i32 - len as i32;
+        if delta >= 0 {
+            self.io_available_bits = delta as u32;
+            self.io_word |= self.io_next_word >> self.io_available_bits;
+        } else {
+            let delta = (-delta) as u32;
+            self.io_word |= self.io_next_word << delta;
+            if !self.read_io_word() {
+                return false;
+            }
+            self.io_available_bits = 32 - delta;
+            self.io_word |= self.io_next_word >> self.io_available_bits;
+        }
+        true
+    }
+
+    fn decode_eat32bits(&mut self) -> bool {
+        self.decode_eatbits(16) && self.decode_eatbits(16)
+    }
+
+    fn reset_channels(&mut self, bpc: u32) -> bool {
+        for c in 0..4 {
+            if !self.channels[c].reset(bpc, self.width) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn quic_decode_begin(&mut self, io_ptr: &[u8]) -> bool {
+        self.reset(io_ptr);
+        if !self.read_io_word() {
+            return false;
+        }
+        self.io_word = self.io_next_word;
+        self.io_available_bits = 0;
+
+        let magic = self.io_word;
+        if !self.decode_eat32bits() {
+            return false;
+        }
+        if magic != 0x4349_5551 {
+            return false;
+        }
+
+        let version = self.io_word;
+        if !self.decode_eat32bits() {
+            return false;
+        }
+        if version != 0 {
+            return false;
+        }
+
+        self.image_type = self.io_word;
+        if !self.decode_eat32bits() {
+            return false;
+        }
+
+        self.width = self.io_word as usize;
+        if !self.decode_eat32bits() {
+            return false;
+        }
+
+        self.height = self.io_word as usize;
+        if !self.decode_eat32bits() {
+            return false;
+        }
+
+        let bpc = quic_image_bpc(self.image_type);
+        self.reset_channels(bpc)
+    }
+
+    fn decode_run(&mut self, state: &mut CommonState) -> Option<usize> {
+        let mut runlen = 0usize;
+        loop {
+            let x = (!(self.io_word >> 24)) & 0xff;
+            let temp = self.zero_lut[x as usize] as usize;
+
+            for _ in 1..=temp {
+                runlen += state.melcorder;
+                if state.melcstate < 32 {
+                    state.melcstate += 1;
+                    state.melclen = J[state.melcstate] as usize;
+                    state.melcorder = 1usize << state.melclen;
+                }
+            }
+
+            if temp != 8 {
+                if !self.decode_eatbits((temp + 1) as u32) {
+                    return None;
+                }
+                break;
+            }
+            if !self.decode_eatbits(8) {
+                return None;
+            }
+        }
+
+        if state.melclen != 0 {
+            runlen += (self.io_word >> (32 - state.melclen as u32)) as usize;
+            if !self.decode_eatbits(state.melclen as u32) {
+                return None;
+            }
+        }
+
+        if state.melcstate != 0 {
+            state.melcstate -= 1;
+            state.melclen = J[state.melcstate] as usize;
+            state.melcorder = 1usize << state.melclen;
+        }
+        Some(runlen)
+    }
+
+    fn decode_run_rgb(&mut self) -> Option<usize> {
+        let mut state = self.rgb_state.clone();
+        let run = self.decode_run(&mut state)?;
+        self.rgb_state = state;
+        Some(run)
+    }
+
+    fn decode_run_channel(&mut self, channel_index: usize) -> Option<usize> {
+        let mut state = self.channels[channel_index].state.clone();
+        let run = self.decode_run(&mut state)?;
+        self.channels[channel_index].state = state;
+        Some(run)
+    }
+
+    fn quic_rgb32_uncompress_row0_seg(
+        &mut self,
+        mut i: usize,
+        cur_row: &mut [u8],
+        end: usize,
+        waitmask: u32,
+        bpc: usize,
+        bpc_mask: u8,
+    ) -> bool {
+        let n_channels = 3usize;
+        let mut stopidx;
+
+        if i == 0 {
+            cur_row[RGB32_PIXEL_PAD] = 0;
+            for c in 0..n_channels {
+                let bestcode = {
+                    let ch = &self.channels[c];
+                    let bidx = ch.buckets_ptrs[ch.correlate_row.zero as usize];
+                    ch.buckets_buf[bidx].bestcode
+                };
+                let (cwlen, rc) = golomb_decoding_8bpc(bestcode, self.io_word, &self.family_8bpc);
+                self.channels[c].correlate_row.row[0] = rc;
+                cur_row[2 - c] = self.family_8bpc.xlat_l2u[rc as usize] as u8;
+                if !self.decode_eatbits(cwlen) {
+                    return false;
+                }
+            }
+
+            if self.rgb_state.waitcnt > 0 {
+                self.rgb_state.waitcnt -= 1;
+            } else {
+                self.rgb_state.waitcnt = (self.rgb_state.tabrand() & waitmask) as usize;
+                for c in 0..n_channels {
+                    let rc0 = self.channels[c].correlate_row.row[0];
+                    let z = self.channels[c].correlate_row.zero as usize;
+                    let bidx = self.channels[c].buckets_ptrs[z];
+                    self.channels[c].buckets_buf[bidx]
+                        .update_model_8bpc(&mut self.rgb_state, rc0, bpc, &self.family_8bpc);
+                }
+            }
+            i += 1;
+            stopidx = i + self.rgb_state.waitcnt;
+        } else {
+            stopidx = i + self.rgb_state.waitcnt;
+        }
+
+        while stopidx < end {
+            while i <= stopidx {
+                let pixel = i * RGB32_PIXEL_SIZE;
+                cur_row[pixel + RGB32_PIXEL_PAD] = 0;
+
+                for c in 0..n_channels {
+                    let prev_idx = self.channels[c].correlate_row.row[i - 1] as usize;
+                    let bidx = self.channels[c].buckets_ptrs[prev_idx];
+                    let bestcode = self.channels[c].buckets_buf[bidx].bestcode;
+                    let (cwlen, rc) = golomb_decoding_8bpc(bestcode, self.io_word, &self.family_8bpc);
+                    self.channels[c].correlate_row.row[i] = rc;
+                    let left = cur_row[(i - 1) * RGB32_PIXEL_SIZE + (2 - c)];
+                    cur_row[pixel + (2 - c)] = self.family_8bpc.xlat_l2u[rc as usize]
+                        .wrapping_add(left as u32) as u8
+                        & bpc_mask;
+                    if !self.decode_eatbits(cwlen) {
+                        return false;
+                    }
+                }
+                i += 1;
+            }
+
+            for c in 0..n_channels {
+                let model_key = self.channels[c].correlate_row.row[stopidx - 1] as usize;
+                let bidx = self.channels[c].buckets_ptrs[model_key];
+                let val = self.channels[c].correlate_row.row[stopidx];
+                self.channels[c].buckets_buf[bidx]
+                    .update_model_8bpc(&mut self.rgb_state, val, bpc, &self.family_8bpc);
+            }
+            stopidx = i + ((self.rgb_state.tabrand() & waitmask) as usize);
+        }
+
+        while i < end {
+            let pixel = i * RGB32_PIXEL_SIZE;
+            cur_row[pixel + RGB32_PIXEL_PAD] = 0;
+
+            for c in 0..n_channels {
+                let prev_idx = self.channels[c].correlate_row.row[i - 1] as usize;
+                let bidx = self.channels[c].buckets_ptrs[prev_idx];
+                let bestcode = self.channels[c].buckets_buf[bidx].bestcode;
+                let (cwlen, rc) = golomb_decoding_8bpc(bestcode, self.io_word, &self.family_8bpc);
+                self.channels[c].correlate_row.row[i] = rc;
+                let left = cur_row[(i - 1) * RGB32_PIXEL_SIZE + (2 - c)];
+                cur_row[pixel + (2 - c)] = self.family_8bpc.xlat_l2u[rc as usize]
+                    .wrapping_add(left as u32) as u8
+                    & bpc_mask;
+                if !self.decode_eatbits(cwlen) {
+                    return false;
+                }
+            }
+            i += 1;
+        }
+        self.rgb_state.waitcnt = stopidx.saturating_sub(end);
+        true
+    }
+
+    fn quic_rgb32_uncompress_row0(&mut self, cur_row: &mut [u8]) -> bool {
+        let mut pos = 0usize;
+        let mut width = self.width;
+
+        while DEFWMIMAX as usize > self.rgb_state.wmidx && self.rgb_state.wmileft <= width {
+            if self.rgb_state.wmileft > 0 {
+                if !self.quic_rgb32_uncompress_row0_seg(
+                    pos,
+                    cur_row,
+                    pos + self.rgb_state.wmileft,
+                    BPPMASK[self.rgb_state.wmidx],
+                    8,
+                    0xff,
+                ) {
+                    return false;
+                }
+                pos += self.rgb_state.wmileft;
+                width -= self.rgb_state.wmileft;
+            }
+            self.rgb_state.wmidx += 1;
+            self.rgb_state.set_wm_trigger();
+            self.rgb_state.wmileft = DEFWMINEXT as usize;
+        }
+
+        if width > 0 {
+            if !self.quic_rgb32_uncompress_row0_seg(
+                pos,
+                cur_row,
+                pos + width,
+                BPPMASK[self.rgb_state.wmidx],
+                8,
+                0xff,
+            ) {
+                return false;
+            }
+            if DEFWMIMAX as usize > self.rgb_state.wmidx {
+                self.rgb_state.wmileft -= width;
+            }
+        }
+        true
+    }
+
+    fn quic_rgb32_uncompress_row_seg(
+        &mut self,
+        prev_row: &[u8],
+        cur_row: &mut [u8],
+        mut i: usize,
+        end: usize,
+        bpc: usize,
+        bpc_mask: u8,
+    ) -> bool {
+        let n_channels = 3usize;
+        let waitmask = BPPMASK[self.rgb_state.wmidx];
+        let mut run_index = 0usize;
+        let mut stopidx;
+
+        if i == 0 {
+            cur_row[RGB32_PIXEL_PAD] = 0;
+            for c in 0..n_channels {
+                let bestcode = {
+                    let ch = &self.channels[c];
+                    let bidx = ch.buckets_ptrs[ch.correlate_row.zero as usize];
+                    ch.buckets_buf[bidx].bestcode
+                };
+                let (cwlen, rc) = golomb_decoding_8bpc(bestcode, self.io_word, &self.family_8bpc);
+                self.channels[c].correlate_row.row[0] = rc;
+                let p = prev_row[2 - c] as u32;
+                cur_row[2 - c] = (self.family_8bpc.xlat_l2u[rc as usize] + p) as u8 & bpc_mask;
+                if !self.decode_eatbits(cwlen) {
+                    return false;
+                }
+            }
+
+            if self.rgb_state.waitcnt > 0 {
+                self.rgb_state.waitcnt -= 1;
+            } else {
+                self.rgb_state.waitcnt = (self.rgb_state.tabrand() & waitmask) as usize;
+                for c in 0..n_channels {
+                    let z = self.channels[c].correlate_row.zero as usize;
+                    let bidx = self.channels[c].buckets_ptrs[z];
+                    let v = self.channels[c].correlate_row.row[0];
+                    self.channels[c].buckets_buf[bidx]
+                        .update_model_8bpc(&mut self.rgb_state, v, bpc, &self.family_8bpc);
+                }
+            }
+            i += 1;
+            stopidx = i + self.rgb_state.waitcnt;
+        } else {
+            stopidx = i + self.rgb_state.waitcnt;
+        }
+
+        loop {
+            let mut rc_break = false;
+
+            while stopidx < end && !rc_break {
+                while i <= stopidx && !rc_break {
+                    let pixel = i * RGB32_PIXEL_SIZE;
+                    let pixelm1 = (i - 1) * RGB32_PIXEL_SIZE;
+                    let pixelm2 = (i.saturating_sub(2)) * RGB32_PIXEL_SIZE;
+
+                    if prev_row[pixelm1 + RGB32_PIXEL_R] == prev_row[pixel + RGB32_PIXEL_R]
+                        && prev_row[pixelm1 + RGB32_PIXEL_G] == prev_row[pixel + RGB32_PIXEL_G]
+                        && prev_row[pixelm1 + RGB32_PIXEL_B] == prev_row[pixel + RGB32_PIXEL_B]
+                        && run_index != i
+                        && i > 2
+                        && cur_row[pixelm1 + RGB32_PIXEL_R] == cur_row[pixelm2 + RGB32_PIXEL_R]
+                        && cur_row[pixelm1 + RGB32_PIXEL_G] == cur_row[pixelm2 + RGB32_PIXEL_G]
+                        && cur_row[pixelm1 + RGB32_PIXEL_B] == cur_row[pixelm2 + RGB32_PIXEL_B]
+                    {
+                        self.rgb_state.waitcnt = stopidx - i;
+                        run_index = i;
+                        let run = match self.decode_run_rgb() {
+                            Some(v) => v,
+                            None => return false,
+                        };
+                        let run_end = i + run;
+
+                        while i < run_end {
+                            let p = i * RGB32_PIXEL_SIZE;
+                            let pm1 = (i - 1) * RGB32_PIXEL_SIZE;
+                            cur_row[p + RGB32_PIXEL_PAD] = 0;
+                            cur_row[p + RGB32_PIXEL_R] = cur_row[pm1 + RGB32_PIXEL_R];
+                            cur_row[p + RGB32_PIXEL_G] = cur_row[pm1 + RGB32_PIXEL_G];
+                            cur_row[p + RGB32_PIXEL_B] = cur_row[pm1 + RGB32_PIXEL_B];
+                            i += 1;
+                        }
+
+                        if i == end {
+                            return true;
+                        }
+
+                        stopidx = i + self.rgb_state.waitcnt;
+                        rc_break = true;
+                        break;
+                    }
+
+                    cur_row[pixel + RGB32_PIXEL_PAD] = 0;
+                    for c in 0..n_channels {
+                        let prev_idx = self.channels[c].correlate_row.row[i - 1] as usize;
+                        let bidx = self.channels[c].buckets_ptrs[prev_idx];
+                        let bestcode = self.channels[c].buckets_buf[bidx].bestcode;
+                        let (cwlen, rc) = golomb_decoding_8bpc(bestcode, self.io_word, &self.family_8bpc);
+                        self.channels[c].correlate_row.row[i] = rc;
+                        let predicted = ((cur_row[pixelm1 + (2 - c)] as u16 + prev_row[pixel + (2 - c)] as u16) >> 1) as u32;
+                        cur_row[pixel + (2 - c)] = (self.family_8bpc.xlat_l2u[rc as usize] + predicted) as u8 & bpc_mask;
+                        if !self.decode_eatbits(cwlen) {
+                            return false;
+                        }
+                    }
+                    i += 1;
+                }
+                if rc_break {
+                    break;
+                }
+
+                for c in 0..n_channels {
+                    let key = self.channels[c].correlate_row.row[stopidx - 1] as usize;
+                    let bidx = self.channels[c].buckets_ptrs[key];
+                    let value = self.channels[c].correlate_row.row[stopidx];
+                    self.channels[c].buckets_buf[bidx]
+                        .update_model_8bpc(&mut self.rgb_state, value, bpc, &self.family_8bpc);
+                }
+                stopidx = i + ((self.rgb_state.tabrand() & waitmask) as usize);
+            }
+
+            while i < end && !rc_break {
+                let pixel = i * RGB32_PIXEL_SIZE;
+                let pixelm1 = (i - 1) * RGB32_PIXEL_SIZE;
+                let pixelm2 = (i.saturating_sub(2)) * RGB32_PIXEL_SIZE;
+
+                if prev_row[pixelm1 + RGB32_PIXEL_R] == prev_row[pixel + RGB32_PIXEL_R]
+                    && prev_row[pixelm1 + RGB32_PIXEL_G] == prev_row[pixel + RGB32_PIXEL_G]
+                    && prev_row[pixelm1 + RGB32_PIXEL_B] == prev_row[pixel + RGB32_PIXEL_B]
+                    && run_index != i
+                    && i > 2
+                    && cur_row[pixelm1 + RGB32_PIXEL_R] == cur_row[pixelm2 + RGB32_PIXEL_R]
+                    && cur_row[pixelm1 + RGB32_PIXEL_G] == cur_row[pixelm2 + RGB32_PIXEL_G]
+                    && cur_row[pixelm1 + RGB32_PIXEL_B] == cur_row[pixelm2 + RGB32_PIXEL_B]
+                {
+                    self.rgb_state.waitcnt = stopidx.saturating_sub(i);
+                    run_index = i;
+                    let run = match self.decode_run_rgb() {
+                        Some(v) => v,
+                        None => return false,
+                    };
+                    let run_end = i + run;
+
+                    while i < run_end {
+                        let p = i * RGB32_PIXEL_SIZE;
+                        let pm1 = (i - 1) * RGB32_PIXEL_SIZE;
+                        cur_row[p + RGB32_PIXEL_PAD] = 0;
+                        cur_row[p + RGB32_PIXEL_R] = cur_row[pm1 + RGB32_PIXEL_R];
+                        cur_row[p + RGB32_PIXEL_G] = cur_row[pm1 + RGB32_PIXEL_G];
+                        cur_row[p + RGB32_PIXEL_B] = cur_row[pm1 + RGB32_PIXEL_B];
+                        i += 1;
+                    }
+
+                    if i == end {
+                        return true;
+                    }
+
+                    stopidx = i + self.rgb_state.waitcnt;
+                    rc_break = true;
+                    break;
+                }
+
+                cur_row[pixel + RGB32_PIXEL_PAD] = 0;
+                for c in 0..n_channels {
+                    let prev_idx = self.channels[c].correlate_row.row[i - 1] as usize;
+                    let bidx = self.channels[c].buckets_ptrs[prev_idx];
+                    let bestcode = self.channels[c].buckets_buf[bidx].bestcode;
+                    let (cwlen, rc) = golomb_decoding_8bpc(bestcode, self.io_word, &self.family_8bpc);
+                    self.channels[c].correlate_row.row[i] = rc;
+                    let predicted = ((cur_row[pixelm1 + (2 - c)] as u16 + prev_row[pixel + (2 - c)] as u16) >> 1) as u32;
+                    cur_row[pixel + (2 - c)] = (self.family_8bpc.xlat_l2u[rc as usize] + predicted) as u8 & bpc_mask;
+                    if !self.decode_eatbits(cwlen) {
+                        return false;
+                    }
+                }
+                i += 1;
+            }
+
+            if !rc_break {
+                self.rgb_state.waitcnt = stopidx.saturating_sub(end);
+                return true;
+            }
+        }
+    }
+
+    fn quic_rgb32_uncompress_row(&mut self, prev_row: &[u8], cur_row: &mut [u8]) -> bool {
+        let mut pos = 0usize;
+        let mut width = self.width;
+
+        while DEFWMIMAX as usize > self.rgb_state.wmidx && self.rgb_state.wmileft <= width {
+            if self.rgb_state.wmileft > 0 {
+                if !self.quic_rgb32_uncompress_row_seg(
+                    prev_row,
+                    cur_row,
+                    pos,
+                    pos + self.rgb_state.wmileft,
+                    8,
+                    0xff,
+                ) {
+                    return false;
+                }
+                pos += self.rgb_state.wmileft;
+                width -= self.rgb_state.wmileft;
+            }
+            self.rgb_state.wmidx += 1;
+            self.rgb_state.set_wm_trigger();
+            self.rgb_state.wmileft = DEFWMINEXT as usize;
+        }
+
+        if width > 0 {
+            if !self.quic_rgb32_uncompress_row_seg(prev_row, cur_row, pos, pos + width, 8, 0xff) {
+                return false;
+            }
+            if DEFWMIMAX as usize > self.rgb_state.wmidx {
+                self.rgb_state.wmileft -= width;
+            }
+        }
+        true
+    }
+
+    fn quic_four_uncompress_row0_seg(
+        &mut self,
+        channel_index: usize,
+        mut i: usize,
+        cur_row: &mut [u8],
+        end: usize,
+        waitmask: u32,
+        bpc: usize,
+        bpc_mask: u8,
+    ) -> bool {
+        let mut stopidx;
+
+        if i == 0 {
+            let bestcode = {
+                let ch = &self.channels[channel_index];
+                let bidx = ch.buckets_ptrs[ch.correlate_row.zero as usize];
+                ch.buckets_buf[bidx].bestcode
+            };
+            let (cwlen, rc) = golomb_decoding_8bpc(bestcode, self.io_word, &self.family_8bpc);
+            self.channels[channel_index].correlate_row.row[0] = rc;
+            cur_row[RGB32_PIXEL_PAD] = self.family_8bpc.xlat_l2u[rc as usize] as u8;
+            if !self.decode_eatbits(cwlen) {
+                return false;
+            }
+
+            if self.channels[channel_index].state.waitcnt > 0 {
+                self.channels[channel_index].state.waitcnt -= 1;
+            } else {
+                let wait = {
+                    let ch = &mut self.channels[channel_index];
+                    (ch.state.tabrand() & waitmask) as usize
+                };
+                self.channels[channel_index].state.waitcnt = wait;
+
+                let z = self.channels[channel_index].correlate_row.zero as usize;
+                let bidx = self.channels[channel_index].buckets_ptrs[z];
+                let val = self.channels[channel_index].correlate_row.row[0];
+                {
+                    let ch = &mut self.channels[channel_index];
+                    let (state, buckets) = (&mut ch.state, &mut ch.buckets_buf);
+                    buckets[bidx].update_model_8bpc(state, val, bpc, &self.family_8bpc);
+                }
+            }
+
+            i += 1;
+            stopidx = i + self.channels[channel_index].state.waitcnt;
+        } else {
+            stopidx = i + self.channels[channel_index].state.waitcnt;
+        }
+
+        while stopidx < end {
+            let mut last_bucket = 0usize;
+            while i <= stopidx {
+                let key = self.channels[channel_index].correlate_row.row[i - 1] as usize;
+                let bidx = self.channels[channel_index].buckets_ptrs[key];
+                last_bucket = bidx;
+
+                let bestcode = self.channels[channel_index].buckets_buf[bidx].bestcode;
+                let (cwlen, rc) = golomb_decoding_8bpc(bestcode, self.io_word, &self.family_8bpc);
+                self.channels[channel_index].correlate_row.row[i] = rc;
+                let left = cur_row[(i - 1) * RGB32_PIXEL_SIZE + RGB32_PIXEL_PAD] as u32;
+                cur_row[i * RGB32_PIXEL_SIZE + RGB32_PIXEL_PAD] =
+                    (self.family_8bpc.xlat_l2u[rc as usize] + left) as u8 & bpc_mask;
+                if !self.decode_eatbits(cwlen) {
+                    return false;
+                }
+                i += 1;
+            }
+
+            let value = self.channels[channel_index].correlate_row.row[stopidx];
+            {
+                let ch = &mut self.channels[channel_index];
+                let (state, buckets) = (&mut ch.state, &mut ch.buckets_buf);
+                buckets[last_bucket].update_model_8bpc(state, value, bpc, &self.family_8bpc);
+            }
+
+            let rand = {
+                let ch = &mut self.channels[channel_index];
+                (ch.state.tabrand() & waitmask) as usize
+            };
+            stopidx = i + rand;
+        }
+
+        while i < end {
+            let key = self.channels[channel_index].correlate_row.row[i - 1] as usize;
+            let bidx = self.channels[channel_index].buckets_ptrs[key];
+            let bestcode = self.channels[channel_index].buckets_buf[bidx].bestcode;
+            let (cwlen, rc) = golomb_decoding_8bpc(bestcode, self.io_word, &self.family_8bpc);
+            self.channels[channel_index].correlate_row.row[i] = rc;
+            let left = cur_row[(i - 1) * RGB32_PIXEL_SIZE + RGB32_PIXEL_PAD] as u32;
+            cur_row[i * RGB32_PIXEL_SIZE + RGB32_PIXEL_PAD] =
+                (self.family_8bpc.xlat_l2u[rc as usize] + left) as u8 & bpc_mask;
+            if !self.decode_eatbits(cwlen) {
+                return false;
+            }
+            i += 1;
+        }
+
+        self.channels[channel_index].state.waitcnt = stopidx.saturating_sub(end);
+        true
+    }
+
+    fn quic_four_uncompress_row0(&mut self, channel_index: usize, cur_row: &mut [u8]) -> bool {
+        let mut pos = 0usize;
+        let mut width = self.width;
+
+        while DEFWMIMAX as usize > self.channels[channel_index].state.wmidx
+            && self.channels[channel_index].state.wmileft <= width
+        {
+            if self.channels[channel_index].state.wmileft > 0 {
+                let segment = self.channels[channel_index].state.wmileft;
+                let waitmask = BPPMASK[self.channels[channel_index].state.wmidx];
+                if !self.quic_four_uncompress_row0_seg(channel_index, pos, cur_row, pos + segment, waitmask, 8, 0xff) {
+                    return false;
+                }
+                pos += segment;
+                width -= segment;
+            }
+
+            self.channels[channel_index].state.wmidx += 1;
+            self.channels[channel_index].state.set_wm_trigger();
+            self.channels[channel_index].state.wmileft = DEFWMINEXT as usize;
+        }
+
+        if width > 0 {
+            let waitmask = BPPMASK[self.channels[channel_index].state.wmidx];
+            if !self.quic_four_uncompress_row0_seg(channel_index, pos, cur_row, pos + width, waitmask, 8, 0xff) {
+                return false;
+            }
+            if DEFWMIMAX as usize > self.channels[channel_index].state.wmidx {
+                self.channels[channel_index].state.wmileft -= width;
+            }
+        }
+        true
+    }
+
+    fn quic_four_uncompress_row_seg(
+        &mut self,
+        channel_index: usize,
+        prev_row: &[u8],
+        cur_row: &mut [u8],
+        mut i: usize,
+        end: usize,
+        bpc: usize,
+        bpc_mask: u8,
+    ) -> bool {
+        let waitmask = BPPMASK[self.channels[channel_index].state.wmidx];
+        let mut run_index = 0usize;
+        let mut stopidx;
+
+        if i == 0 {
+            let bestcode = {
+                let ch = &self.channels[channel_index];
+                let bidx = ch.buckets_ptrs[ch.correlate_row.zero as usize];
+                ch.buckets_buf[bidx].bestcode
+            };
+            let (cwlen, rc) = golomb_decoding_8bpc(bestcode, self.io_word, &self.family_8bpc);
+            self.channels[channel_index].correlate_row.row[0] = rc;
+            cur_row[RGB32_PIXEL_PAD] =
+                (self.family_8bpc.xlat_l2u[rc as usize] + prev_row[RGB32_PIXEL_PAD] as u32) as u8
+                    & bpc_mask;
+            if !self.decode_eatbits(cwlen) {
+                return false;
+            }
+
+            if self.channels[channel_index].state.waitcnt > 0 {
+                self.channels[channel_index].state.waitcnt -= 1;
+            } else {
+                let wait = {
+                    let ch = &mut self.channels[channel_index];
+                    (ch.state.tabrand() & waitmask) as usize
+                };
+                self.channels[channel_index].state.waitcnt = wait;
+                let z = self.channels[channel_index].correlate_row.zero as usize;
+                let bidx = self.channels[channel_index].buckets_ptrs[z];
+                let value = self.channels[channel_index].correlate_row.row[0];
+                {
+                    let ch = &mut self.channels[channel_index];
+                    let (state, buckets) = (&mut ch.state, &mut ch.buckets_buf);
+                    buckets[bidx].update_model_8bpc(state, value, bpc, &self.family_8bpc);
+                }
+            }
+
+            i += 1;
+            stopidx = i + self.channels[channel_index].state.waitcnt;
+        } else {
+            stopidx = i + self.channels[channel_index].state.waitcnt;
+        }
+
+        loop {
+            let mut rc_break = false;
+
+            while stopidx < end && !rc_break {
+                let mut last_bucket = 0usize;
+                while i <= stopidx && !rc_break {
+                    let pixel = i * RGB32_PIXEL_SIZE;
+                    let pixelm1 = (i - 1) * RGB32_PIXEL_SIZE;
+                    let pixelm2 = (i.saturating_sub(2)) * RGB32_PIXEL_SIZE;
+
+                    if prev_row[pixelm1 + RGB32_PIXEL_PAD] == prev_row[pixel + RGB32_PIXEL_PAD]
+                        && run_index != i
+                        && i > 2
+                        && cur_row[pixelm1 + RGB32_PIXEL_PAD] == cur_row[pixelm2 + RGB32_PIXEL_PAD]
+                    {
+                        self.channels[channel_index].state.waitcnt = stopidx - i;
+                        run_index = i;
+                        let run = match self.decode_run_channel(channel_index) {
+                            Some(v) => v,
+                            None => return false,
+                        };
+                        let run_end = i + run;
+                        while i < run_end {
+                            let p = i * RGB32_PIXEL_SIZE;
+                            let pm1 = (i - 1) * RGB32_PIXEL_SIZE;
+                            cur_row[p + RGB32_PIXEL_PAD] = cur_row[pm1 + RGB32_PIXEL_PAD];
+                            i += 1;
+                        }
+
+                        if i == end {
+                            return true;
+                        }
+                        stopidx = i + self.channels[channel_index].state.waitcnt;
+                        rc_break = true;
+                        break;
+                    }
+
+                    let key = self.channels[channel_index].correlate_row.row[i - 1] as usize;
+                    let bidx = self.channels[channel_index].buckets_ptrs[key];
+                    last_bucket = bidx;
+                    let bestcode = self.channels[channel_index].buckets_buf[bidx].bestcode;
+                    let (cwlen, rc) = golomb_decoding_8bpc(bestcode, self.io_word, &self.family_8bpc);
+                    self.channels[channel_index].correlate_row.row[i] = rc;
+                    let predicted =
+                        ((cur_row[pixelm1 + RGB32_PIXEL_PAD] as u16 + prev_row[pixel + RGB32_PIXEL_PAD] as u16)
+                            >> 1) as u32;
+                    cur_row[pixel + RGB32_PIXEL_PAD] =
+                        (self.family_8bpc.xlat_l2u[rc as usize] + predicted) as u8 & bpc_mask;
+                    if !self.decode_eatbits(cwlen) {
+                        return false;
+                    }
+                    i += 1;
+                }
+
+                if rc_break {
+                    break;
+                }
+
+                let value = self.channels[channel_index].correlate_row.row[stopidx];
+                {
+                    let ch = &mut self.channels[channel_index];
+                    let (state, buckets) = (&mut ch.state, &mut ch.buckets_buf);
+                    buckets[last_bucket].update_model_8bpc(state, value, bpc, &self.family_8bpc);
+                }
+
+                let rand = {
+                    let ch = &mut self.channels[channel_index];
+                    (ch.state.tabrand() & waitmask) as usize
+                };
+                stopidx = i + rand;
+            }
+
+            while i < end && !rc_break {
+                let pixel = i * RGB32_PIXEL_SIZE;
+                let pixelm1 = (i - 1) * RGB32_PIXEL_SIZE;
+                let pixelm2 = (i.saturating_sub(2)) * RGB32_PIXEL_SIZE;
+                if prev_row[pixelm1 + RGB32_PIXEL_PAD] == prev_row[pixel + RGB32_PIXEL_PAD]
+                    && run_index != i
+                    && i > 2
+                    && cur_row[pixelm1 + RGB32_PIXEL_PAD] == cur_row[pixelm2 + RGB32_PIXEL_PAD]
+                {
+                    self.channels[channel_index].state.waitcnt = stopidx.saturating_sub(i);
+                    run_index = i;
+                    let run = match self.decode_run_channel(channel_index) {
+                        Some(v) => v,
+                        None => return false,
+                    };
+                    let run_end = i + run;
+                    while i < run_end {
+                        let p = i * RGB32_PIXEL_SIZE;
+                        let pm1 = (i - 1) * RGB32_PIXEL_SIZE;
+                        cur_row[p + RGB32_PIXEL_PAD] = cur_row[pm1 + RGB32_PIXEL_PAD];
+                        i += 1;
+                    }
+                    if i == end {
+                        return true;
+                    }
+                    stopidx = i + self.channels[channel_index].state.waitcnt;
+                    rc_break = true;
+                    break;
+                }
+
+                let key = self.channels[channel_index].correlate_row.row[i - 1] as usize;
+                let bidx = self.channels[channel_index].buckets_ptrs[key];
+                let bestcode = self.channels[channel_index].buckets_buf[bidx].bestcode;
+                let (cwlen, rc) = golomb_decoding_8bpc(bestcode, self.io_word, &self.family_8bpc);
+                self.channels[channel_index].correlate_row.row[i] = rc;
+                let predicted =
+                    ((cur_row[pixelm1 + RGB32_PIXEL_PAD] as u16 + prev_row[pixel + RGB32_PIXEL_PAD] as u16)
+                        >> 1) as u32;
+                cur_row[pixel + RGB32_PIXEL_PAD] =
+                    (self.family_8bpc.xlat_l2u[rc as usize] + predicted) as u8 & bpc_mask;
+                if !self.decode_eatbits(cwlen) {
+                    return false;
+                }
+                i += 1;
+            }
+
+            if !rc_break {
+                self.channels[channel_index].state.waitcnt = stopidx.saturating_sub(end);
+                return true;
+            }
+        }
+    }
+
+    fn quic_four_uncompress_row(
+        &mut self,
+        channel_index: usize,
+        prev_row: &[u8],
+        cur_row: &mut [u8],
+    ) -> bool {
+        let mut pos = 0usize;
+        let mut width = self.width;
+
+        while DEFWMIMAX as usize > self.channels[channel_index].state.wmidx
+            && self.channels[channel_index].state.wmileft <= width
+        {
+            if self.channels[channel_index].state.wmileft > 0 {
+                let seg = self.channels[channel_index].state.wmileft;
+                if !self.quic_four_uncompress_row_seg(channel_index, prev_row, cur_row, pos, pos + seg, 8, 0xff) {
+                    return false;
+                }
+                pos += seg;
+                width -= seg;
+            }
+
+            self.channels[channel_index].state.wmidx += 1;
+            self.channels[channel_index].state.set_wm_trigger();
+            self.channels[channel_index].state.wmileft = DEFWMINEXT as usize;
+        }
+
+        if width > 0 {
+            if !self.quic_four_uncompress_row_seg(channel_index, prev_row, cur_row, pos, pos + width, 8, 0xff) {
+                return false;
+            }
+            if DEFWMIMAX as usize > self.channels[channel_index].state.wmidx {
+                self.channels[channel_index].state.wmileft -= width;
+            }
+        }
+        true
+    }
+
+    fn quic_decode(&mut self, buf: &mut [u8], stride: usize) -> bool {
+        match self.image_type {
+            QUIC_IMAGE_TYPE_RGB32 | QUIC_IMAGE_TYPE_RGB24 => {
+                self.channels[0].correlate_row.zero = 0;
+                self.channels[1].correlate_row.zero = 0;
+                self.channels[2].correlate_row.zero = 0;
+
+                if !self.quic_rgb32_uncompress_row0(&mut buf[..stride]) {
+                    return false;
+                }
+
+                self.rows_completed += 1;
+                for row in 1..self.height {
+                    let split = row * stride;
+                    let (head, tail) = buf.split_at_mut(split);
+                    let prev_row = &head[(split - stride)..split];
+                    let cur_row = &mut tail[..stride];
+
+                    self.channels[0].correlate_row.zero = self.channels[0].correlate_row.row[0];
+                    self.channels[1].correlate_row.zero = self.channels[1].correlate_row.row[0];
+                    self.channels[2].correlate_row.zero = self.channels[2].correlate_row.row[0];
+
+                    if !self.quic_rgb32_uncompress_row(prev_row, cur_row) {
+                        return false;
+                    }
+                    self.rows_completed += 1;
+                }
+                true
+            }
+            QUIC_IMAGE_TYPE_RGBA => {
+                self.channels[0].correlate_row.zero = 0;
+                self.channels[1].correlate_row.zero = 0;
+                self.channels[2].correlate_row.zero = 0;
+                if !self.quic_rgb32_uncompress_row0(&mut buf[..stride]) {
+                    return false;
+                }
+
+                self.channels[3].correlate_row.zero = 0;
+                if !self.quic_four_uncompress_row0(3, &mut buf[..stride]) {
+                    return false;
+                }
+
+                self.rows_completed += 1;
+                for row in 1..self.height {
+                    let split = row * stride;
+                    let (head, tail) = buf.split_at_mut(split);
+                    let prev_row = &head[(split - stride)..split];
+                    let cur_row = &mut tail[..stride];
+
+                    self.channels[0].correlate_row.zero = self.channels[0].correlate_row.row[0];
+                    self.channels[1].correlate_row.zero = self.channels[1].correlate_row.row[0];
+                    self.channels[2].correlate_row.zero = self.channels[2].correlate_row.row[0];
+                    if !self.quic_rgb32_uncompress_row(prev_row, cur_row) {
+                        return false;
+                    }
+
+                    self.channels[3].correlate_row.zero = self.channels[3].correlate_row.row[0];
+                    if !self.quic_four_uncompress_row(3, prev_row, cur_row) {
+                        return false;
+                    }
+                    self.rows_completed += 1;
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+pub fn quic_decode(data: &[u8], width: u32, height: u32) -> Option<Vec<u8>> {
+    debug!("quic: decode: data_len={}, expected={}x{}", data.len(), width, height);
+    let mut decoder = QuicDecoder::new();
+    if !decoder.quic_decode_begin(data) {
+        warn!("quic: decode_begin failed");
+        return None;
+    }
+    debug!("quic: header: type={}, size={}x{}", decoder.image_type, decoder.width, decoder.height);
+
+    if decoder.image_type != QUIC_IMAGE_TYPE_RGB32
+        && decoder.image_type != QUIC_IMAGE_TYPE_RGB24
+        && decoder.image_type != QUIC_IMAGE_TYPE_RGBA
+    {
+        warn!("quic: unsupported image type: {}", decoder.image_type);
+        return None;
+    }
+
+    if decoder.width as u32 != width || decoder.height as u32 != height {
+        warn!("quic: size mismatch: quic={}x{} vs expected={}x{}", decoder.width, decoder.height, width, height);
+        return None;
+    }
+
+    let stride = decoder.width.checked_mul(4)?;
+    let total = decoder.height.checked_mul(stride)?;
+    let mut native = vec![0u8; total];
+    if !decoder.quic_decode(&mut native, stride) {
+        warn!("quic: decode failed");
+        return None;
+    }
+
+    let mut rgba = vec![0u8; total];
+    for i in (0..total).step_by(4) {
+        let b = native[i + 0];
+        let g = native[i + 1];
+        let r = native[i + 2];
+        rgba[i + 0] = r;
+        rgba[i + 1] = g;
+        rgba[i + 2] = b;
+        rgba[i + 3] = if decoder.image_type == QUIC_IMAGE_TYPE_RGBA {
+            255u8.wrapping_sub(native[i + 3])
+        } else {
+            255
+        };
+    }
+
+    Some(rgba)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,8 @@ fn run_headless(
 
     let runtime = tokio::runtime::Runtime::new()?;
     runtime.block_on(async {
-        app::run_headless(config, args.cadence, virtual_disks, share_dir, capture).await
+        app::run_headless(config, args.cadence, virtual_disks, share_dir, capture, args.monitors)
+            .await
     })
 }
 
@@ -160,6 +161,7 @@ fn run_gui(
     };
 
     let cadence = args.cadence;
+    let monitors = args.monitors;
     eframe::run_native(
         "Ryll - SPICE Client",
         native_options,
@@ -171,6 +173,7 @@ fn run_gui(
                 virtual_disks,
                 share_dir,
                 capture,
+                monitors,
             )))
         }),
     )

--- a/src/protocol/constants.rs
+++ b/src/protocol/constants.rs
@@ -144,6 +144,10 @@ pub mod main_server {
     pub const NOTIFY: u16 = 7;
     pub const INIT: u16 = 103;
     pub const CHANNELS_LIST: u16 = 104;
+    pub const AGENT_CONNECTED: u16 = 108;
+    pub const AGENT_DISCONNECTED: u16 = 109;
+    pub const AGENT_DATA: u16 = 110;
+    pub const AGENT_TOKEN: u16 = 111;
 }
 
 /// Main channel message types (client -> server)
@@ -155,6 +159,9 @@ pub mod main_client {
     pub const MIGRATE_DATA: u16 = 5;
     pub const DISCONNECTING: u16 = 6;
     pub const ATTACH_CHANNELS: u16 = 104;
+    pub const AGENT_START: u16 = 106;
+    pub const AGENT_DATA: u16 = 107;
+    pub const AGENT_TOKEN: u16 = 108;
 }
 
 /// Display channel message types (server -> client)
@@ -288,6 +295,9 @@ pub enum ImageType {
     JpegAlpha = 108,
     Lz4 = 109,
 }
+
+#[allow(dead_code)]
+pub const IMAGE_FLAGS_CACHE_ME: u8 = 1 << 0;
 
 impl ImageType {
     pub fn from_u8(value: u8) -> Option<Self> {

--- a/src/protocol/logging.rs
+++ b/src/protocol/logging.rs
@@ -118,6 +118,10 @@ pub mod message_names {
             main_server::NOTIFY => "notify",
             main_server::INIT => "init",
             main_server::CHANNELS_LIST => "channels_list",
+            main_server::AGENT_CONNECTED => "agent_connected",
+            main_server::AGENT_DISCONNECTED => "agent_disconnected",
+            main_server::AGENT_DATA => "agent_data",
+            main_server::AGENT_TOKEN => "agent_token",
             _ => "unknown",
         }
     }
@@ -132,6 +136,9 @@ pub mod message_names {
             main_client::MIGRATE_DATA => "migrate_data",
             main_client::DISCONNECTING => "disconnecting",
             main_client::ATTACH_CHANNELS => "attach_channels",
+            main_client::AGENT_START => "agent_start",
+            main_client::AGENT_DATA => "agent_data",
+            main_client::AGENT_TOKEN => "agent_token",
             _ => "unknown",
         }
     }

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -259,13 +259,14 @@ pub struct DrawCopyBase {
     pub bottom: u32,
     pub right: u32,
     pub clip_type: u8,
+    pub clip_rects: Vec<(u32, u32, u32, u32)>,
+    /// Byte offset past this struct (including any variable-length clip rects)
+    pub end_offset: usize,
 }
 
 impl DrawCopyBase {
-    pub const SIZE: usize = 21;
-
     pub fn read(data: &[u8]) -> io::Result<Self> {
-        if data.len() < Self::SIZE {
+        if data.len() < 21 {
             return Err(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
                 "Not enough data for DrawCopyBase",
@@ -273,13 +274,73 @@ impl DrawCopyBase {
         }
 
         let mut cursor = Cursor::new(data);
+        let surface_id = cursor.read_u32::<LittleEndian>()?;
+        let top = cursor.read_u32::<LittleEndian>()?;
+        let left = cursor.read_u32::<LittleEndian>()?;
+        let bottom = cursor.read_u32::<LittleEndian>()?;
+        let right = cursor.read_u32::<LittleEndian>()?;
+        let clip_type = cursor.read_u8()?;
+
+        let mut offset = 21usize;
+        let mut clip_rects = Vec::new();
+
+        // SPICE_CLIP_TYPE_RECTS = 1: followed by u32 count + count * SpiceRect(16 bytes)
+        if clip_type == 1 {
+            if data.len() < offset + 4 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "Not enough data for clip rects count",
+                ));
+            }
+            let num_rects = u32::from_le_bytes([
+                data[offset], data[offset + 1], data[offset + 2], data[offset + 3],
+            ]) as usize;
+            offset += 4;
+            if data.len() < offset + num_rects * 16 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "Not enough data for clip rects",
+                ));
+            }
+            for _ in 0..num_rects {
+                let top = u32::from_le_bytes([
+                    data[offset],
+                    data[offset + 1],
+                    data[offset + 2],
+                    data[offset + 3],
+                ]);
+                let left = u32::from_le_bytes([
+                    data[offset + 4],
+                    data[offset + 5],
+                    data[offset + 6],
+                    data[offset + 7],
+                ]);
+                let bottom = u32::from_le_bytes([
+                    data[offset + 8],
+                    data[offset + 9],
+                    data[offset + 10],
+                    data[offset + 11],
+                ]);
+                let right = u32::from_le_bytes([
+                    data[offset + 12],
+                    data[offset + 13],
+                    data[offset + 14],
+                    data[offset + 15],
+                ]);
+                clip_rects.push((left, top, right, bottom));
+                offset += 16;
+            }
+        }
+
         Ok(DrawCopyBase {
-            surface_id: cursor.read_u32::<LittleEndian>()?,
-            top: cursor.read_u32::<LittleEndian>()?,
-            left: cursor.read_u32::<LittleEndian>()?,
-            bottom: cursor.read_u32::<LittleEndian>()?,
-            right: cursor.read_u32::<LittleEndian>()?,
-            clip_type: cursor.read_u8()?,
+            surface_id,
+            top,
+            left,
+            bottom,
+            right,
+            clip_type,
+            clip_rects,
+            end_offset: offset,
         })
     }
 }
@@ -481,8 +542,19 @@ impl MousePosition {
 pub struct MouseButton;
 
 impl MouseButton {
+    fn mask_to_id(mask: u32) -> u32 {
+        match mask {
+            0x01 => 1, // LEFT
+            0x02 => 2, // MIDDLE
+            0x04 => 3, // RIGHT
+            0x08 => 4, // UP (scroll)
+            0x10 => 5, // DOWN (scroll)
+            _ => 0,
+        }
+    }
+
     pub fn write(button: u32, buttons_state: u32, buf: &mut Vec<u8>) -> io::Result<()> {
-        buf.write_u32::<LittleEndian>(button)?;
+        buf.write_u32::<LittleEndian>(Self::mask_to_id(button))?;
         buf.write_u32::<LittleEndian>(buttons_state)?;
         Ok(())
     }

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -458,12 +458,17 @@ impl CursorSet {
     }
 }
 
-/// SpiceCursor header — precedes cursor pixel data in INIT and SET messages
+/// SpiceCursor — flags field that precedes the optional SpiceCursorHeader.
+///
+/// Wire layout:
+///   u16 flags
+///   [SpiceCursorHeader]  — only present when FLAG_NONE is NOT set
+///   [pixel data]         — only present when FLAG_FROM_CACHE is NOT set
 #[derive(Debug, Clone)]
 pub struct SpiceCursorHeader {
-    pub flags: u32,
+    pub flags: u16,
     pub unique_id: u64,
-    pub cursor_type: u16,
+    pub cursor_type: u8,
     pub width: u16,
     pub height: u16,
     pub hot_spot_x: u16,
@@ -471,14 +476,32 @@ pub struct SpiceCursorHeader {
 }
 
 impl SpiceCursorHeader {
-    pub const SIZE: usize = 22;
+    /// Size of just the flags field (always present).
+    pub const FLAGS_SIZE: usize = 2;
+    /// Size of flags + cursor header (when header is present).
+    pub const SIZE: usize = 19;
 
-    /// Cursor should be cached by unique_id
-    pub const FLAG_CACHE_ME: u32 = 1 << 1;
-    /// No pixel data follows — look up by unique_id
-    pub const FLAG_FROM_CACHE: u32 = 1 << 2;
+    pub const FLAG_NONE: u16 = 1 << 0;
+    pub const FLAG_CACHE_ME: u16 = 1 << 1;
+    pub const FLAG_FROM_CACHE: u16 = 1 << 2;
 
-    pub fn read(data: &[u8]) -> io::Result<Self> {
+    /// Read the flags field and, if FLAG_NONE is not set, the full header.
+    /// Returns None when FLAG_NONE is set (no cursor data follows).
+    pub fn read(data: &[u8]) -> io::Result<Option<Self>> {
+        if data.len() < Self::FLAGS_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Not enough data for SpiceCursor flags",
+            ));
+        }
+
+        let mut cursor = Cursor::new(data);
+        let flags = cursor.read_u16::<LittleEndian>()?;
+
+        if flags & Self::FLAG_NONE != 0 {
+            return Ok(None);
+        }
+
         if data.len() < Self::SIZE {
             return Err(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
@@ -486,16 +509,15 @@ impl SpiceCursorHeader {
             ));
         }
 
-        let mut cursor = Cursor::new(data);
-        Ok(SpiceCursorHeader {
-            flags: cursor.read_u32::<LittleEndian>()?,
+        Ok(Some(SpiceCursorHeader {
+            flags,
             unique_id: cursor.read_u64::<LittleEndian>()?,
-            cursor_type: cursor.read_u16::<LittleEndian>()?,
+            cursor_type: cursor.read_u8()?,
             width: cursor.read_u16::<LittleEndian>()?,
             height: cursor.read_u16::<LittleEndian>()?,
             hot_spot_x: cursor.read_u16::<LittleEndian>()?,
             hot_spot_y: cursor.read_u16::<LittleEndian>()?,
-        })
+        }))
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix mouse right-click sent as scroll-up (button bitmask→ID conversion)
- Share GLZ dictionary across display channels with async retry on cross-image miss
- Isolate surfaces by (display_channel_id, surface_id) preventing cross-channel conflicts
- Add QUIC image decode support (pure Rust, ported from spice_viewer)
- Add SPICE agent infrastructure: capabilities, monitors config, token management
- Add --monitors CLI arg for multi-monitor control
- Connect all display/cursor channels on startup (enable/disable via monitors config)

## Display rendering fixes

- INVAL_LIST: remove only listed IDs instead of clearing entire cache
- LZ/GLZ/LZ4: handle top_down flag (flip when false)
- DrawCopy: use src_bitmap offset, parse variable-length clip rects, apply src_area crop
- MouseUp: send MOUSE_POSITION before MOUSE_RELEASE (matches spice-gtk)

## Agent infrastructure

- Main channel agent start + capabilities announcement
- VDAgentMonitorsConfig sent on window resize (200ms debounce)
- Single monitor: num_mon=1 flags=0; multi: num_mon=N flags=1
- Agent token tracking and AGENT_DATA from server handling

## Verified against

- spice-gtk (GLZ dictionary sharing, mouse position before button events)
- spice-html5 (monitors config format, all-channels-connected behavior)
- spice_viewer (QUIC decoder, agent message format)
- /home/openclaw/spice_proxy/docs/multi-display.md (protocol semantics)