### PR TITLE
Add clipboard, MJPEG stream, modifier keys, disconnect handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,9 +259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
 dependencies = [
  "clipboard-win",
+ "image",
  "log",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
@@ -1059,10 +1062,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1379,6 +1407,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "emath"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +1537,26 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "fdeflate"
@@ -1909,6 +1963,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2142,7 +2207,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2274,6 +2339,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png",
+ "tiff",
  "zune-core",
  "zune-jpeg",
 ]
@@ -2412,6 +2478,15 @@ checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
+]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
+dependencies = [
+ "rayon",
 ]
 
 [[package]]
@@ -3569,6 +3644,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,6 +3753,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3938,6 +4039,7 @@ name = "ryll"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "arboard",
  "async-channel",
  "byteorder",
  "bytes",
@@ -3953,6 +4055,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "image",
+ "jpeg-decoder",
  "lz4_flex",
  "mp4",
  "nusb",
@@ -4490,6 +4593,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5229,6 +5346,12 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,12 +52,16 @@ flate2 = "1"
 
 # JPEG decoding for SPICE JPEG image type
 image = { version = "0.25", default-features = false, features = ["jpeg"] }
+jpeg-decoder = "0.3"
 
 # Capture mode (--capture) — optional, disabled on Windows
 pcap-file = { version = "2", optional = true }
 etherparse = { version = "0.16", optional = true }
 openh264 = { version = "0.6", optional = true }
 mp4 = { version = "0.14", optional = true }
+
+# Clipboard access (host ↔ guest copy/paste)
+arboard = "3"
 
 # Signal handling (Ctrl+C graceful shutdown, cross-platform)
 ctrlc = "3"

--- a/src/app.rs
+++ b/src/app.rs
@@ -602,8 +602,10 @@ impl RyllApp {
                     self.connected = false;
                     if !self.show_disconnect_dialog {
                         self.show_disconnect_dialog = true;
-                        self.disconnect_reason =
-                            Some(format!("Connection lost ({} channel disconnected)", channel.name()));
+                        self.disconnect_reason = Some(format!(
+                            "Connection lost ({} channel disconnected)",
+                            channel.name()
+                        ));
                     }
                     if channel == ChannelType::Usbredir {
                         self.usb_channel_ready = false;

--- a/src/app.rs
+++ b/src/app.rs
@@ -151,9 +151,12 @@ pub struct RyllApp {
     connected: bool,
     error_message: Option<String>,
     mouse_mode: u32, // 1=server, 2=client
+    show_disconnect_dialog: bool,
+    disconnect_reason: Option<String>,
 
     // Last mouse position sent (to avoid flooding with duplicates)
     last_mouse_pos: Option<(u32, u32)>,
+    last_modifiers: Option<egui::Modifiers>,
 
     // Bitmask of mouse buttons we have forwarded as pressed to the
     // inputs channel.  Used to send synthetic releases when input
@@ -335,7 +338,10 @@ impl RyllApp {
             connected: false,
             error_message: None,
             mouse_mode: 0,
+            show_disconnect_dialog: false,
+            disconnect_reason: None,
             last_mouse_pos: None,
+            last_modifiers: None,
             forwarded_buttons: 0,
             pending_resize: None,
             bandwidth: BandwidthTracker::new(byte_counter),
@@ -512,6 +518,14 @@ impl RyllApp {
                     debug!("app: requested monitors config {}x{}", width, height);
                 }
 
+                ChannelEvent::ClipboardReceived { text } => {
+                    info!("app: clipboard from guest ({} bytes)", text.len());
+                    match arboard::Clipboard::new().and_then(|mut cb| cb.set_text(&text)) {
+                        Ok(()) => {}
+                        Err(e) => debug!("app: failed to set host clipboard: {}", e),
+                    }
+                }
+
                 ChannelEvent::Statistics {
                     bytes_in,
                     bytes_out,
@@ -527,7 +541,8 @@ impl RyllApp {
 
                 ChannelEvent::Error(msg) => {
                     error!("app: channel error: {}", msg);
-                    self.error_message = Some(msg);
+                    self.show_disconnect_dialog = true;
+                    self.disconnect_reason = Some(msg);
                 }
 
                 ChannelEvent::UsbChannelReady => {
@@ -584,8 +599,11 @@ impl RyllApp {
 
                 ChannelEvent::Disconnected(channel) => {
                     info!("app: channel {} disconnected", channel.name());
-                    if channel == ChannelType::Main {
-                        self.connected = false;
+                    self.connected = false;
+                    if !self.show_disconnect_dialog {
+                        self.show_disconnect_dialog = true;
+                        self.disconnect_reason =
+                            Some(format!("Connection lost ({} channel disconnected)", channel.name()));
                     }
                     if channel == ChannelType::Usbredir {
                         self.usb_channel_ready = false;
@@ -736,7 +754,6 @@ impl RyllApp {
                     ..
                 } = event
                 {
-                    // F11/F12 are consumed by the traffic viewer / bug report shortcuts
                     if *key == egui::Key::F11 || *key == egui::Key::F12 {
                         continue;
                     }
@@ -746,14 +763,40 @@ impl RyllApp {
                         } else {
                             InputEvent::KeyUp(up_code)
                         };
-                        debug!(
-                            "app: key {:?} pressed={} scancode={:#x}",
-                            key, pressed, down_code
-                        );
                         let _ = input_tx.try_send(ev);
                     }
                 }
             }
+
+            let mods = i.modifiers;
+            let prev = self.last_modifiers.unwrap_or_default();
+
+            if mods.ctrl != prev.ctrl {
+                let code = 0x1D; // Left Ctrl
+                if mods.ctrl {
+                    let _ = input_tx.try_send(InputEvent::KeyDown(code));
+                } else {
+                    let _ = input_tx.try_send(InputEvent::KeyUp(code | 0x80));
+                }
+            }
+            if mods.shift != prev.shift {
+                let code = 0x2A; // Left Shift
+                if mods.shift {
+                    let _ = input_tx.try_send(InputEvent::KeyDown(code));
+                } else {
+                    let _ = input_tx.try_send(InputEvent::KeyUp(code | 0x80));
+                }
+            }
+            if mods.alt != prev.alt {
+                let code = 0x38; // Left Alt
+                if mods.alt {
+                    let _ = input_tx.try_send(InputEvent::KeyDown(code));
+                } else {
+                    let _ = input_tx.try_send(InputEvent::KeyUp(code | 0x80));
+                }
+            }
+
+            self.last_modifiers = Some(mods);
         });
     }
 
@@ -1845,9 +1888,26 @@ impl eframe::App for RyllApp {
             }
         }
 
-        // Repaint at ~60 fps to keep input responsive (clicks, key
-        // presses).  Incoming events also trigger repaints via
-        // request_repaint() from the connection thread.
+        if self.show_disconnect_dialog {
+            let reason = self
+                .disconnect_reason
+                .as_deref()
+                .unwrap_or("Unknown reason");
+            egui::Window::new("Disconnected")
+                .collapsible(false)
+                .resizable(false)
+                .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+                .show(ctx, |ui| {
+                    ui.label(reason);
+                    ui.add_space(8.0);
+                    ui.horizontal(|ui| {
+                        if ui.button("Close").clicked() {
+                            std::process::exit(0);
+                        }
+                    });
+                });
+        }
+
         ctx.request_repaint_after(std::time::Duration::from_millis(16));
     }
 }
@@ -2173,7 +2233,7 @@ pub async fn run_headless(
         Some(tokio::spawn(async move {
             loop {
                 tokio::time::sleep(Duration::from_secs(2)).await;
-                let _ = input_tx.try_send(InputEvent::KeyDown(0x39)); // Space
+                let _ = input_tx.try_send(InputEvent::KeyDown(0x39));
                 let _ = input_tx.try_send(InputEvent::KeyUp(0xB9));
             }
         }))

--- a/src/bugreport.rs
+++ b/src/bugreport.rs
@@ -224,7 +224,10 @@ impl TrafficBuffers {
         let wire_size = raw_message.len() as u32;
         let payload_size = wire_size.saturating_sub(6);
 
-        let mut guard = buf.lock().unwrap();
+        let mut guard = match buf.lock() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
         let pcap_frame = self.build_frame(channel, false, raw_message, &mut guard);
         let entry = TrafficEntry {
             timestamp: elapsed,

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -126,6 +126,9 @@ pub(crate) fn build_tcp_frame(
     tcp.ack = true;
 
     let ip_payload_len = tcp.header_len() + tcp_payload_len;
+    if ip_payload_len > 65515 {
+        return Vec::new();
+    }
     let mut ipv4 =
         Ipv4Header::new(ip_payload_len as u16, 64, IpNumber::TCP, src_ip, dst_ip).unwrap();
     ipv4.dont_fragment = true;

--- a/src/channels/display.rs
+++ b/src/channels/display.rs
@@ -22,6 +22,108 @@ use crate::settings;
 
 use super::ChannelEvent;
 
+const SPICE_VIDEO_CODEC_TYPE_MJPEG: u8 = 1;
+
+fn extract_dht_segments(jpeg: &[u8]) -> Vec<u8> {
+    let mut dht = Vec::new();
+    let mut i = 0;
+    while i + 3 < jpeg.len() {
+        if jpeg[i] != 0xFF {
+            i += 1;
+            continue;
+        }
+        let marker = jpeg[i + 1];
+        if marker == 0xC4 {
+            let seg_len = u16::from_be_bytes([jpeg[i + 2], jpeg[i + 3]]) as usize + 2;
+            if i + seg_len <= jpeg.len() {
+                dht.extend_from_slice(&jpeg[i..i + seg_len]);
+            }
+            i += seg_len;
+        } else if marker == 0xD8 || marker == 0x00 || (0xD0..=0xD7).contains(&marker) {
+            i += 2;
+        } else if marker == 0xD9 || marker == 0xDA {
+            break;
+        } else {
+            if i + 3 < jpeg.len() {
+                let seg_len = u16::from_be_bytes([jpeg[i + 2], jpeg[i + 3]]) as usize + 2;
+                i += seg_len;
+            } else {
+                break;
+            }
+        }
+    }
+    dht
+}
+
+fn inject_dht(jpeg: &[u8], dht: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(jpeg.len() + dht.len());
+    let mut i = 0;
+    // SOI marker
+    if jpeg.len() >= 2 && jpeg[0] == 0xFF && jpeg[1] == 0xD8 {
+        out.extend_from_slice(&jpeg[..2]);
+        i = 2;
+    }
+    // skip APP0/APP1 if present
+    while i + 3 < jpeg.len() && jpeg[i] == 0xFF && (jpeg[i + 1] == 0xE0 || jpeg[i + 1] == 0xE1) {
+        let seg_len = u16::from_be_bytes([jpeg[i + 2], jpeg[i + 3]]) as usize + 2;
+        out.extend_from_slice(&jpeg[i..i + seg_len]);
+        i += seg_len;
+    }
+    out.extend_from_slice(dht);
+    out.extend_from_slice(&jpeg[i..]);
+    out
+}
+
+fn decode_mjpeg_frame(data: &[u8]) -> Option<(Vec<u8>, u32, u32)> {
+    let mut decoder = jpeg_decoder::Decoder::new(data);
+    let pixels = match decoder.decode() {
+        Ok(p) => p,
+        Err(e) => {
+            warn!("MJPEG decode error: {}, data_len={}, header={:02x?}", e, data.len(), &data[..data.len().min(16)]);
+            return None;
+        }
+    };
+    let info = decoder.info()?;
+    let w = info.width as u32;
+    let h = info.height as u32;
+
+    let rgba = match info.pixel_format {
+        jpeg_decoder::PixelFormat::RGB24 => {
+            let mut out = Vec::with_capacity(pixels.len() * 4 / 3);
+            for chunk in pixels.chunks(3) {
+                out.push(chunk[0]);
+                out.push(chunk[1]);
+                out.push(chunk[2]);
+                out.push(255);
+            }
+            out
+        }
+        jpeg_decoder::PixelFormat::L8 => {
+            let mut out = Vec::with_capacity(pixels.len() * 4);
+            for &gray in &pixels {
+                out.push(gray);
+                out.push(gray);
+                out.push(gray);
+                out.push(255);
+            }
+            out
+        }
+        _ => return None,
+    };
+
+    Some((rgba, w, h))
+}
+
+struct StreamState {
+    surface_id: u32,
+    codec_type: u8,
+    dest_top: u32,
+    dest_left: u32,
+    dest_bottom: u32,
+    dest_right: u32,
+    cached_dht: Option<Vec<u8>>,
+}
+
 /// Decompress a SPICE LZ4 image.
 ///
 /// Format: 1 byte top_down, 1 byte spice_format, then per-row blocks
@@ -156,6 +258,7 @@ pub struct DisplayChannel {
     buffer: Vec<u8>,
     glz_dictionary: SharedGlzDictionary,
     image_cache: HashMap<u64, Vec<u8>>,
+    streams: HashMap<u32, StreamState>,
     capture: Option<Arc<CaptureSession>>,
     byte_counter: Arc<ByteCounter>,
     traffic: Arc<TrafficBuffers>,
@@ -192,6 +295,7 @@ impl DisplayChannel {
             buffer: Vec::with_capacity(1024 * 1024),
             glz_dictionary,
             image_cache: HashMap::new(),
+            streams: HashMap::new(),
             capture,
             byte_counter,
             traffic,
@@ -532,6 +636,130 @@ impl DisplayChannel {
                 info!("display: reset");
                 self.image_cache.clear();
                 self.glz_dictionary.lock().unwrap().clear();
+            }
+
+            display_server::STREAM_CREATE => {
+                if payload.len() >= 50 {
+                    let surface_id = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+                    let stream_id = u32::from_le_bytes([payload[4], payload[5], payload[6], payload[7]]);
+                    let _flags = payload[8];
+                    let codec_type = payload[9];
+                    let stream_w = u32::from_le_bytes([payload[18], payload[19], payload[20], payload[21]]);
+                    let stream_h = u32::from_le_bytes([payload[22], payload[23], payload[24], payload[25]]);
+                    let dest_top = u32::from_le_bytes([payload[34], payload[35], payload[36], payload[37]]);
+                    let dest_left = u32::from_le_bytes([payload[38], payload[39], payload[40], payload[41]]);
+                    let dest_bottom = u32::from_le_bytes([payload[42], payload[43], payload[44], payload[45]]);
+                    let dest_right = u32::from_le_bytes([payload[46], payload[47], payload[48], payload[49]]);
+
+                    info!(
+                        "display: stream_create: id={}, surface={}, codec={}, {}x{}, dest=({},{})→({},{})",
+                        stream_id, surface_id, codec_type, stream_w, stream_h,
+                        dest_left, dest_top, dest_right, dest_bottom
+                    );
+
+                    self.streams.insert(stream_id, StreamState {
+                        surface_id,
+                        codec_type,
+                        dest_top,
+                        dest_left,
+                        dest_bottom,
+                        dest_right,
+                        cached_dht: None,
+                    });
+                }
+            }
+
+            display_server::STREAM_DATA | display_server::STREAM_DATA_SIZED => {
+                let (stream_id, dest, jpeg_data) = if msg_type == display_server::STREAM_DATA_SIZED {
+                    if payload.len() < 36 {
+                        return Ok(());
+                    }
+                    let id = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+                    let dest_top = u32::from_le_bytes([payload[16], payload[17], payload[18], payload[19]]);
+                    let dest_left = u32::from_le_bytes([payload[20], payload[21], payload[22], payload[23]]);
+                    let dest_bottom = u32::from_le_bytes([payload[24], payload[25], payload[26], payload[27]]);
+                    let dest_right = u32::from_le_bytes([payload[28], payload[29], payload[30], payload[31]]);
+                    let data_size = u32::from_le_bytes([payload[32], payload[33], payload[34], payload[35]]) as usize;
+                    let data = &payload[36..36 + data_size.min(payload.len() - 36)];
+                    (id, Some((dest_top, dest_left, dest_bottom, dest_right)), data)
+                } else {
+                    if payload.len() < 12 {
+                        return Ok(());
+                    }
+                    let id = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+                    let data_size = u32::from_le_bytes([payload[8], payload[9], payload[10], payload[11]]) as usize;
+                    let data = &payload[12..12 + data_size.min(payload.len() - 12)];
+                    (id, None, data)
+                };
+
+                if let Some(stream) = self.streams.get_mut(&stream_id) {
+                    if stream.codec_type == SPICE_VIDEO_CODEC_TYPE_MJPEG {
+                        let (top, left, bottom, right) = dest.unwrap_or((
+                            stream.dest_top, stream.dest_left,
+                            stream.dest_bottom, stream.dest_right,
+                        ));
+                        let w = right.saturating_sub(left);
+                        let h = bottom.saturating_sub(top);
+
+                        let dht = extract_dht_segments(jpeg_data);
+                        let decode_data;
+                        let frame_data = if !dht.is_empty() {
+                            stream.cached_dht = Some(dht);
+                            jpeg_data
+                        } else if let Some(ref cached) = stream.cached_dht {
+                            decode_data = inject_dht(jpeg_data, cached);
+                            &decode_data
+                        } else {
+                            jpeg_data
+                        };
+
+                        match decode_mjpeg_frame(frame_data) {
+                            Some((rgba, fw, fh)) => {
+                                debug!(
+                                    "display: stream {} MJPEG frame {}x{} → ({},{})",
+                                    stream_id, fw, fh, left, top
+                                );
+                                self.event_tx
+                                    .send(ChannelEvent::ImageReady {
+                                        display_channel_id: self.channel_id,
+                                        surface_id: stream.surface_id,
+                                        left,
+                                        top,
+                                        width: fw.min(w),
+                                        height: fh.min(h),
+                                        pixels: rgba,
+                                        image_id: 0,
+                                    })
+                                    .await
+                                    .ok();
+                            }
+                            None => {
+                                debug!("display: stream {} MJPEG decode failed", stream_id);
+                            }
+                        }
+                    } else {
+                        debug!("display: stream {} unsupported codec {}", stream_id, stream.codec_type);
+                    }
+                }
+            }
+
+            display_server::STREAM_CLIP => {
+                if payload.len() >= 4 {
+                    let stream_id = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+                    debug!("display: stream_clip id={}", stream_id);
+                }
+            }
+
+            display_server::STREAM_DESTROY => {
+                if payload.len() >= 4 {
+                    let stream_id = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+                    info!("display: stream_destroy id={}", stream_id);
+                    self.streams.remove(&stream_id);
+                }
+            }
+
+            display_server::STREAM_ACTIVATE_REPORT => {
+                debug!("display: stream_activate_report");
             }
 
             _ => {

--- a/src/channels/display.rs
+++ b/src/channels/display.rs
@@ -79,7 +79,12 @@ fn decode_mjpeg_frame(data: &[u8]) -> Option<(Vec<u8>, u32, u32)> {
     let pixels = match decoder.decode() {
         Ok(p) => p,
         Err(e) => {
-            warn!("MJPEG decode error: {}, data_len={}, header={:02x?}", e, data.len(), &data[..data.len().min(16)]);
+            warn!(
+                "MJPEG decode error: {}, data_len={}, header={:02x?}",
+                e,
+                data.len(),
+                &data[..data.len().min(16)]
+            );
             return None;
         }
     };
@@ -640,16 +645,24 @@ impl DisplayChannel {
 
             display_server::STREAM_CREATE => {
                 if payload.len() >= 50 {
-                    let surface_id = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
-                    let stream_id = u32::from_le_bytes([payload[4], payload[5], payload[6], payload[7]]);
+                    let surface_id =
+                        u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+                    let stream_id =
+                        u32::from_le_bytes([payload[4], payload[5], payload[6], payload[7]]);
                     let _flags = payload[8];
                     let codec_type = payload[9];
-                    let stream_w = u32::from_le_bytes([payload[18], payload[19], payload[20], payload[21]]);
-                    let stream_h = u32::from_le_bytes([payload[22], payload[23], payload[24], payload[25]]);
-                    let dest_top = u32::from_le_bytes([payload[34], payload[35], payload[36], payload[37]]);
-                    let dest_left = u32::from_le_bytes([payload[38], payload[39], payload[40], payload[41]]);
-                    let dest_bottom = u32::from_le_bytes([payload[42], payload[43], payload[44], payload[45]]);
-                    let dest_right = u32::from_le_bytes([payload[46], payload[47], payload[48], payload[49]]);
+                    let stream_w =
+                        u32::from_le_bytes([payload[18], payload[19], payload[20], payload[21]]);
+                    let stream_h =
+                        u32::from_le_bytes([payload[22], payload[23], payload[24], payload[25]]);
+                    let dest_top =
+                        u32::from_le_bytes([payload[34], payload[35], payload[36], payload[37]]);
+                    let dest_left =
+                        u32::from_le_bytes([payload[38], payload[39], payload[40], payload[41]]);
+                    let dest_bottom =
+                        u32::from_le_bytes([payload[42], payload[43], payload[44], payload[45]]);
+                    let dest_right =
+                        u32::from_le_bytes([payload[46], payload[47], payload[48], payload[49]]);
 
                     info!(
                         "display: stream_create: id={}, surface={}, codec={}, {}x{}, dest=({},{})→({},{})",
@@ -657,37 +670,53 @@ impl DisplayChannel {
                         dest_left, dest_top, dest_right, dest_bottom
                     );
 
-                    self.streams.insert(stream_id, StreamState {
-                        surface_id,
-                        codec_type,
-                        dest_top,
-                        dest_left,
-                        dest_bottom,
-                        dest_right,
-                        cached_dht: None,
-                    });
+                    self.streams.insert(
+                        stream_id,
+                        StreamState {
+                            surface_id,
+                            codec_type,
+                            dest_top,
+                            dest_left,
+                            dest_bottom,
+                            dest_right,
+                            cached_dht: None,
+                        },
+                    );
                 }
             }
 
             display_server::STREAM_DATA | display_server::STREAM_DATA_SIZED => {
-                let (stream_id, dest, jpeg_data) = if msg_type == display_server::STREAM_DATA_SIZED {
+                let (stream_id, dest, jpeg_data) = if msg_type == display_server::STREAM_DATA_SIZED
+                {
                     if payload.len() < 36 {
                         return Ok(());
                     }
                     let id = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
-                    let dest_top = u32::from_le_bytes([payload[16], payload[17], payload[18], payload[19]]);
-                    let dest_left = u32::from_le_bytes([payload[20], payload[21], payload[22], payload[23]]);
-                    let dest_bottom = u32::from_le_bytes([payload[24], payload[25], payload[26], payload[27]]);
-                    let dest_right = u32::from_le_bytes([payload[28], payload[29], payload[30], payload[31]]);
-                    let data_size = u32::from_le_bytes([payload[32], payload[33], payload[34], payload[35]]) as usize;
+                    let dest_top =
+                        u32::from_le_bytes([payload[16], payload[17], payload[18], payload[19]]);
+                    let dest_left =
+                        u32::from_le_bytes([payload[20], payload[21], payload[22], payload[23]]);
+                    let dest_bottom =
+                        u32::from_le_bytes([payload[24], payload[25], payload[26], payload[27]]);
+                    let dest_right =
+                        u32::from_le_bytes([payload[28], payload[29], payload[30], payload[31]]);
+                    let data_size =
+                        u32::from_le_bytes([payload[32], payload[33], payload[34], payload[35]])
+                            as usize;
                     let data = &payload[36..36 + data_size.min(payload.len() - 36)];
-                    (id, Some((dest_top, dest_left, dest_bottom, dest_right)), data)
+                    (
+                        id,
+                        Some((dest_top, dest_left, dest_bottom, dest_right)),
+                        data,
+                    )
                 } else {
                     if payload.len() < 12 {
                         return Ok(());
                     }
                     let id = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
-                    let data_size = u32::from_le_bytes([payload[8], payload[9], payload[10], payload[11]]) as usize;
+                    let data_size =
+                        u32::from_le_bytes([payload[8], payload[9], payload[10], payload[11]])
+                            as usize;
                     let data = &payload[12..12 + data_size.min(payload.len() - 12)];
                     (id, None, data)
                 };
@@ -695,8 +724,10 @@ impl DisplayChannel {
                 if let Some(stream) = self.streams.get_mut(&stream_id) {
                     if stream.codec_type == SPICE_VIDEO_CODEC_TYPE_MJPEG {
                         let (top, left, bottom, right) = dest.unwrap_or((
-                            stream.dest_top, stream.dest_left,
-                            stream.dest_bottom, stream.dest_right,
+                            stream.dest_top,
+                            stream.dest_left,
+                            stream.dest_bottom,
+                            stream.dest_right,
                         ));
                         let w = right.saturating_sub(left);
                         let h = bottom.saturating_sub(top);
@@ -738,21 +769,26 @@ impl DisplayChannel {
                             }
                         }
                     } else {
-                        debug!("display: stream {} unsupported codec {}", stream_id, stream.codec_type);
+                        debug!(
+                            "display: stream {} unsupported codec {}",
+                            stream_id, stream.codec_type
+                        );
                     }
                 }
             }
 
             display_server::STREAM_CLIP => {
                 if payload.len() >= 4 {
-                    let stream_id = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+                    let stream_id =
+                        u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
                     debug!("display: stream_clip id={}", stream_id);
                 }
             }
 
             display_server::STREAM_DESTROY => {
                 if payload.len() >= 4 {
-                    let stream_id = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+                    let stream_id =
+                        u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
                     info!("display: stream_destroy id={}", stream_id);
                     self.streams.remove(&stream_id);
                 }

--- a/src/channels/main_channel.rs
+++ b/src/channels/main_channel.rs
@@ -400,12 +400,11 @@ impl MainChannel {
 
             main_server::AGENT_DATA => {
                 if payload.len() >= 20 {
-                    let agent_type = u32::from_le_bytes([
-                        payload[4], payload[5], payload[6], payload[7],
-                    ]);
-                    let agent_size = u32::from_le_bytes([
-                        payload[16], payload[17], payload[18], payload[19],
-                    ]) as usize;
+                    let agent_type =
+                        u32::from_le_bytes([payload[4], payload[5], payload[6], payload[7]]);
+                    let agent_size =
+                        u32::from_le_bytes([payload[16], payload[17], payload[18], payload[19]])
+                            as usize;
                     let agent_payload = &payload[20..20 + agent_size.min(payload.len() - 20)];
                     debug!(
                         "main: agent_data from server: type={}, size={}",
@@ -604,9 +603,8 @@ impl MainChannel {
             VD_AGENT_CLIPBOARD_GRAB => {
                 // payload: selection(u32) + format(u32)
                 if payload.len() >= 8 {
-                    let format = u32::from_le_bytes([
-                        payload[4], payload[5], payload[6], payload[7],
-                    ]);
+                    let format =
+                        u32::from_le_bytes([payload[4], payload[5], payload[6], payload[7]]);
                     if format == VD_AGENT_CLIPBOARD_UTF8_TEXT {
                         debug!("main: clipboard grab from guest, requesting data");
                         self.send_clipboard_request().await?;
@@ -618,7 +616,10 @@ impl MainChannel {
                 let offset = 4;
                 if payload.len() > offset + 4 {
                     let _format = u32::from_le_bytes([
-                        payload[offset], payload[offset + 1], payload[offset + 2], payload[offset + 3],
+                        payload[offset],
+                        payload[offset + 1],
+                        payload[offset + 2],
+                        payload[offset + 3],
                     ]);
                     let data = &payload[offset + 4..];
                     if !data.is_empty() {
@@ -638,9 +639,8 @@ impl MainChannel {
             VD_AGENT_CLIPBOARD_REQUEST => {
                 // payload: selection(u32) + format(u32)
                 if payload.len() >= 8 {
-                    let format = u32::from_le_bytes([
-                        payload[4], payload[5], payload[6], payload[7],
-                    ]);
+                    let format =
+                        u32::from_le_bytes([payload[4], payload[5], payload[6], payload[7]]);
                     if format == VD_AGENT_CLIPBOARD_UTF8_TEXT {
                         debug!("main: clipboard request from guest");
                         match arboard::Clipboard::new().and_then(|mut cb| cb.get_text()) {
@@ -661,9 +661,8 @@ impl MainChannel {
                 self.guest_caps_received = true;
                 debug!("main: received agent capabilities from guest");
                 if payload.len() >= 4 {
-                    let request = u32::from_le_bytes([
-                        payload[0], payload[1], payload[2], payload[3],
-                    ]);
+                    let request =
+                        u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
                     if request == 1 {
                         self.agent_caps_announced = false;
                         self.maybe_send_announce_capabilities().await?;
@@ -709,14 +708,16 @@ impl MainChannel {
         let mut payload = Vec::with_capacity(8);
         payload.write_u32::<LittleEndian>(0)?;
         payload.write_u32::<LittleEndian>(VD_AGENT_CLIPBOARD_UTF8_TEXT)?;
-        self.send_agent_data_message(VD_AGENT_CLIPBOARD_GRAB, &payload).await
+        self.send_agent_data_message(VD_AGENT_CLIPBOARD_GRAB, &payload)
+            .await
     }
 
     async fn send_clipboard_request(&mut self) -> Result<bool> {
         let mut payload = Vec::with_capacity(8);
         payload.write_u32::<LittleEndian>(0)?;
         payload.write_u32::<LittleEndian>(VD_AGENT_CLIPBOARD_UTF8_TEXT)?;
-        self.send_agent_data_message(VD_AGENT_CLIPBOARD_REQUEST, &payload).await
+        self.send_agent_data_message(VD_AGENT_CLIPBOARD_REQUEST, &payload)
+            .await
     }
 
     async fn send_clipboard_data(&mut self, text: &str) -> Result<bool> {
@@ -725,7 +726,8 @@ impl MainChannel {
         payload.write_u32::<LittleEndian>(0)?;
         payload.write_u32::<LittleEndian>(VD_AGENT_CLIPBOARD_UTF8_TEXT)?;
         payload.extend_from_slice(text_bytes);
-        self.send_agent_data_message(VD_AGENT_CLIPBOARD, &payload).await
+        self.send_agent_data_message(VD_AGENT_CLIPBOARD, &payload)
+            .await
     }
 
     async fn send_with_log(&mut self, msg_type: u16, data: &[u8]) -> Result<()> {

--- a/src/channels/main_channel.rs
+++ b/src/channels/main_channel.rs
@@ -21,9 +21,17 @@ use super::ChannelEvent;
 const VD_AGENT_PROTOCOL: u32 = 1;
 const VD_AGENT_ANNOUNCE_CAPABILITIES: u32 = 1;
 const VD_AGENT_MONITORS_CONFIG: u32 = 2;
+const VD_AGENT_CLIPBOARD: u32 = 4;
+const VD_AGENT_CLIPBOARD_GRAB: u32 = 7;
+const VD_AGENT_CLIPBOARD_REQUEST: u32 = 8;
+const VD_AGENT_CLIPBOARD_RELEASE: u32 = 9;
+const VD_AGENT_CLIPBOARD_UTF8_TEXT: u32 = 1;
+
 const VD_AGENT_CAP_MOUSE_STATE: u32 = 0;
 const VD_AGENT_CAP_MONITORS_CONFIG: u32 = 1;
 const VD_AGENT_CAP_REPLY: u32 = 2;
+const VD_AGENT_CAP_CLIPBOARD_BY_DEMAND: u32 = 5;
+const VD_AGENT_CAP_CLIPBOARD_SELECTION: u32 = 6;
 const VD_AGENT_CONFIG_MONITORS_FLAG_USE_POS: u32 = 1;
 
 pub struct MainChannel {
@@ -34,10 +42,13 @@ pub struct MainChannel {
     agent_connected: bool,
     agent_tokens: u32,
     agent_caps_announced: bool,
+    guest_caps_received: bool,
+    channels_requested: bool,
     monitors: u8,
     monitors_config_rx: mpsc::Receiver<(u32, u32)>,
     pending_monitors_config: Option<(u32, u32)>,
     last_sent_monitors_config: Option<(u32, u32)>,
+    last_clipboard_text: Option<String>,
     capture: Option<Arc<CaptureSession>>,
     byte_counter: Arc<ByteCounter>,
     traffic: Arc<TrafficBuffers>,
@@ -70,6 +81,9 @@ impl MainChannel {
             monitors_config_rx,
             pending_monitors_config: None,
             last_sent_monitors_config: None,
+            guest_caps_received: false,
+            channels_requested: false,
+            last_clipboard_text: None,
             capture,
             byte_counter,
             traffic,
@@ -89,6 +103,10 @@ impl MainChannel {
         info!("main: channel started");
 
         let mut resize_debounce: Option<tokio::time::Instant> = None;
+        let mut clipboard_interval = tokio::time::interval(std::time::Duration::from_millis(500));
+        clipboard_interval.tick().await;
+        let mut last_data_received = tokio::time::Instant::now();
+        let keepalive_timeout = std::time::Duration::from_secs(30);
 
         loop {
             let mut chunk = [0u8; 65536];
@@ -125,6 +143,7 @@ impl MainChannel {
                         break;
                     }
 
+                    last_data_received = tokio::time::Instant::now();
                     self.byte_counter.add(n as u64);
                     if let Some(ref c) = self.capture {
                         c.packet_received("main", &chunk[..n]);
@@ -156,6 +175,19 @@ impl MainChannel {
                             .ok();
                         self.maybe_send_agent_monitors_config().await?;
                     }
+                }
+                _ = clipboard_interval.tick() => {
+                    if self.agent_connected && self.agent_caps_announced {
+                        self.poll_host_clipboard().await?;
+                    }
+                }
+                _ = tokio::time::sleep_until(last_data_received + keepalive_timeout) => {
+                    info!("main: no data received for {}s, assuming disconnected", keepalive_timeout.as_secs());
+                    self.event_tx
+                        .send(ChannelEvent::Disconnected(ChannelType::Main))
+                        .await
+                        .ok();
+                    break;
                 }
             }
         }
@@ -297,7 +329,8 @@ impl MainChannel {
                 self.send_with_log(main_client::PONG, &response).await?;
 
                 // Request channel list on first large ping
-                if ping.id > 0 && self.session_id.is_some() {
+                if ping.id > 0 && self.session_id.is_some() && !self.channels_requested {
+                    self.channels_requested = true;
                     self.request_channels_list().await?;
                 }
             }
@@ -362,18 +395,23 @@ impl MainChannel {
                 info!("main: vdagent disconnected");
                 self.agent_connected = false;
                 self.agent_caps_announced = false;
+                self.guest_caps_received = false;
             }
 
             main_server::AGENT_DATA => {
-                if payload.len() >= 16 {
-                    let agent_type =
-                        u32::from_le_bytes([payload[4], payload[5], payload[6], payload[7]]);
-                    let agent_size =
-                        u32::from_le_bytes([payload[12], payload[13], payload[14], payload[15]]);
+                if payload.len() >= 20 {
+                    let agent_type = u32::from_le_bytes([
+                        payload[4], payload[5], payload[6], payload[7],
+                    ]);
+                    let agent_size = u32::from_le_bytes([
+                        payload[16], payload[17], payload[18], payload[19],
+                    ]) as usize;
+                    let agent_payload = &payload[20..20 + agent_size.min(payload.len() - 20)];
                     debug!(
                         "main: agent_data from server: type={}, size={}",
                         agent_type, agent_size
                     );
+                    self.handle_agent_message(agent_type, agent_payload).await?;
                 } else {
                     debug!(
                         "main: agent_data from server: {} bytes: {:02x?}",
@@ -437,7 +475,9 @@ impl MainChannel {
 
         let caps = (1u32 << VD_AGENT_CAP_MOUSE_STATE)
             | (1u32 << VD_AGENT_CAP_MONITORS_CONFIG)
-            | (1u32 << VD_AGENT_CAP_REPLY);
+            | (1u32 << VD_AGENT_CAP_REPLY)
+            | (1u32 << VD_AGENT_CAP_CLIPBOARD_BY_DEMAND)
+            | (1u32 << VD_AGENT_CAP_CLIPBOARD_SELECTION);
         let mut payload = Vec::with_capacity(8);
         payload.write_u32::<LittleEndian>(1)?;
         payload.write_u32::<LittleEndian>(caps)?;
@@ -523,12 +563,6 @@ impl MainChannel {
             active, flags
         );
 
-        debug!(
-            "main: monitors config payload ({} bytes): {:02x?}",
-            payload.len(),
-            payload
-        );
-
         self.send_agent_data_message(VD_AGENT_MONITORS_CONFIG, &payload)
             .await
     }
@@ -538,23 +572,160 @@ impl MainChannel {
             return Ok(false);
         }
 
-        let mut agent = Vec::with_capacity(16 + payload.len());
+        let mut agent = Vec::with_capacity(20 + payload.len());
         agent.write_u32::<LittleEndian>(VD_AGENT_PROTOCOL)?;
         agent.write_u32::<LittleEndian>(ty)?;
         agent.write_u64::<LittleEndian>(0)?;
         agent.write_u32::<LittleEndian>(payload.len() as u32)?;
         agent.extend_from_slice(payload);
 
-        debug!(
-            "main: agent_data wrapper ({} bytes): {:02x?}",
-            agent.len(),
-            agent
-        );
-        let msg = make_message(main_client::AGENT_DATA, &agent);
-        self.send_with_log(main_client::AGENT_DATA, &msg).await?;
-        self.agent_tokens = self.agent_tokens.saturating_sub(1);
+        const MAX_CHUNK: usize = 2048 - 6;
+        let mut offset = 0;
+        while offset < agent.len() {
+            if self.agent_tokens == 0 {
+                return Ok(false);
+            }
+            let end = (offset + MAX_CHUNK).min(agent.len());
+            let msg = make_message(main_client::AGENT_DATA, &agent[offset..end]);
+            self.send_with_log(main_client::AGENT_DATA, &msg).await?;
+            self.agent_tokens = self.agent_tokens.saturating_sub(1);
+            offset = end;
+        }
 
         Ok(true)
+    }
+
+    async fn handle_agent_message(&mut self, agent_type: u32, payload: &[u8]) -> Result<()> {
+        if !self.guest_caps_received {
+            self.guest_caps_received = true;
+            debug!("main: guest agent active");
+        }
+        match agent_type {
+            VD_AGENT_CLIPBOARD_GRAB => {
+                // payload: selection(u32) + format(u32)
+                if payload.len() >= 8 {
+                    let format = u32::from_le_bytes([
+                        payload[4], payload[5], payload[6], payload[7],
+                    ]);
+                    if format == VD_AGENT_CLIPBOARD_UTF8_TEXT {
+                        debug!("main: clipboard grab from guest, requesting data");
+                        self.send_clipboard_request().await?;
+                    }
+                }
+            }
+            VD_AGENT_CLIPBOARD => {
+                // payload: selection(u32) + format(u32) + data
+                let offset = 4;
+                if payload.len() > offset + 4 {
+                    let _format = u32::from_le_bytes([
+                        payload[offset], payload[offset + 1], payload[offset + 2], payload[offset + 3],
+                    ]);
+                    let data = &payload[offset + 4..];
+                    if !data.is_empty() {
+                        let text = String::from_utf8_lossy(data).to_string();
+                        info!(
+                            "main: clipboard from guest ({} bytes): {:?}",
+                            text.len(),
+                            &text.chars().take(16).collect::<String>()
+                        );
+                        match arboard::Clipboard::new().and_then(|mut cb| cb.set_text(&text)) {
+                            Ok(()) => debug!("main: host clipboard updated"),
+                            Err(e) => debug!("main: clipboard set failed: {}", e),
+                        }
+                    }
+                }
+            }
+            VD_AGENT_CLIPBOARD_REQUEST => {
+                // payload: selection(u32) + format(u32)
+                if payload.len() >= 8 {
+                    let format = u32::from_le_bytes([
+                        payload[4], payload[5], payload[6], payload[7],
+                    ]);
+                    if format == VD_AGENT_CLIPBOARD_UTF8_TEXT {
+                        debug!("main: clipboard request from guest");
+                        match arboard::Clipboard::new().and_then(|mut cb| cb.get_text()) {
+                            Ok(text) => {
+                                self.send_clipboard_data(&text).await?;
+                            }
+                            Err(e) => {
+                                debug!("main: failed to read host clipboard: {}", e);
+                            }
+                        }
+                    }
+                }
+            }
+            VD_AGENT_CLIPBOARD_RELEASE => {
+                debug!("main: clipboard release from guest");
+            }
+            VD_AGENT_ANNOUNCE_CAPABILITIES => {
+                self.guest_caps_received = true;
+                debug!("main: received agent capabilities from guest");
+                if payload.len() >= 4 {
+                    let request = u32::from_le_bytes([
+                        payload[0], payload[1], payload[2], payload[3],
+                    ]);
+                    if request == 1 {
+                        self.agent_caps_announced = false;
+                        self.maybe_send_announce_capabilities().await?;
+                    }
+                }
+            }
+            _ => {
+                debug!("main: unhandled agent message type={}", agent_type);
+            }
+        }
+        Ok(())
+    }
+
+    async fn poll_host_clipboard(&mut self) -> Result<()> {
+        let text = match arboard::Clipboard::new().and_then(|mut cb| cb.get_text()) {
+            Ok(t) => t,
+            Err(_) => return Ok(()),
+        };
+
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        let changed = match &self.last_clipboard_text {
+            Some(prev) => prev != &text,
+            None => true,
+        };
+
+        if changed {
+            info!(
+                "main: host clipboard changed ({} bytes): {:?}",
+                text.len(),
+                &text.chars().take(16).collect::<String>()
+            );
+            self.last_clipboard_text = Some(text);
+            self.send_clipboard_grab().await?;
+        }
+
+        Ok(())
+    }
+
+    async fn send_clipboard_grab(&mut self) -> Result<bool> {
+        let mut payload = Vec::with_capacity(8);
+        payload.write_u32::<LittleEndian>(0)?;
+        payload.write_u32::<LittleEndian>(VD_AGENT_CLIPBOARD_UTF8_TEXT)?;
+        self.send_agent_data_message(VD_AGENT_CLIPBOARD_GRAB, &payload).await
+    }
+
+    async fn send_clipboard_request(&mut self) -> Result<bool> {
+        let mut payload = Vec::with_capacity(8);
+        payload.write_u32::<LittleEndian>(0)?;
+        payload.write_u32::<LittleEndian>(VD_AGENT_CLIPBOARD_UTF8_TEXT)?;
+        self.send_agent_data_message(VD_AGENT_CLIPBOARD_REQUEST, &payload).await
+    }
+
+    async fn send_clipboard_data(&mut self, text: &str) -> Result<bool> {
+        let text_bytes = text.as_bytes();
+        let mut payload = Vec::with_capacity(8 + text_bytes.len());
+        payload.write_u32::<LittleEndian>(0)?;
+        payload.write_u32::<LittleEndian>(VD_AGENT_CLIPBOARD_UTF8_TEXT)?;
+        payload.extend_from_slice(text_bytes);
+        self.send_agent_data_message(VD_AGENT_CLIPBOARD, &payload).await
     }
 
     async fn send_with_log(&mut self, msg_type: u16, data: &[u8]) -> Result<()> {

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -74,6 +74,9 @@ pub enum ChannelEvent {
         height: u32,
     },
 
+    #[allow(dead_code)]
+    ClipboardReceived { text: String },
+
     /// Statistics update (reserved for future use)
     #[allow(dead_code)]
     Statistics {

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -75,7 +75,9 @@ pub enum ChannelEvent {
     },
 
     #[allow(dead_code)]
-    ClipboardReceived { text: String },
+    ClipboardReceived {
+        text: String,
+    },
 
     /// Statistics update (reserved for future use)
     #[allow(dead_code)]

--- a/src/protocol/constants.rs
+++ b/src/protocol/constants.rs
@@ -144,10 +144,10 @@ pub mod main_server {
     pub const NOTIFY: u16 = 7;
     pub const INIT: u16 = 103;
     pub const CHANNELS_LIST: u16 = 104;
-    pub const AGENT_CONNECTED: u16 = 108;
-    pub const AGENT_DISCONNECTED: u16 = 109;
-    pub const AGENT_DATA: u16 = 110;
-    pub const AGENT_TOKEN: u16 = 111;
+    pub const AGENT_CONNECTED: u16 = 107;
+    pub const AGENT_DISCONNECTED: u16 = 108;
+    pub const AGENT_DATA: u16 = 109;
+    pub const AGENT_TOKEN: u16 = 110;
 }
 
 /// Main channel message types (client -> server)


### PR DESCRIPTION
## Summary

Adds bidirectional clipboard, MJPEG video stream decoding, modifier key support, and connection disconnect handling.

## Clipboard (via SPICE agent)

- Bidirectional text clipboard between guest and host
- Host→Guest: poll host clipboard every 500ms, send CLIPBOARD_GRAB on change, respond to CLIPBOARD_REQUEST
- Guest→Host: handle CLIPBOARD_GRAB/DATA, decode UTF-8 text, write to host clipboard via arboard
- Agent message chunking (max 2042 bytes per SPICE message) to prevent server disconnect on large clipboard
- Wait for guest agent to be active before clipboard operations
- Fix agent opcode mapping: AGENT_DATA=109 (was incorrectly 110)
- Fix VDAgentMessage size field offset: byte 16 (was incorrectly 12)

## MJPEG Video Stream

- Handle STREAM_CREATE/DATA/DATA_SIZED/CLIP/DESTROY opcodes
- MJPEG decode via jpeg-decoder crate (more lenient than image crate for SPICE streams)
- DHT (Huffman table) caching: extract from first frame, inject into subsequent frames that omit DHT
- Stream state tracking per stream_id with surface/dest/codec info

## Input

- Modifier keys (Ctrl/Shift/Alt) now sent to guest by tracking egui modifiers state changes per frame

## Connection Handling

- Disconnect dialog shown when any channel disconnects
- 30-second keepalive timeout on main channel (detects silent network failures)
- Channel list requested only once (was duplicated on every ping response)

## Bug Fixes

- Fix capture.rs panic on oversized TCP payload (>65515 bytes)
- Fix bugreport.rs PoisonError cascade after capture panic
- Fix UTF-8 panic when truncating clipboard text containing multi-byte characters (e.g. Chinese)

## Verified against

- spice-html5 (clipboard protocol, agent message chunking, DHT handling)
- spice_viewer (MJPEG decode via jpeg-decoder)