### PR TITLE
Add scroll wheel, modifier keys, fix opcode logging

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -154,6 +154,7 @@ pub struct RyllApp {
 
     // Last mouse position sent (to avoid flooding with duplicates)
     last_mouse_pos: Option<(u32, u32)>,
+    last_modifiers: Option<egui::Modifiers>,
 
     // Bitmask of mouse buttons we have forwarded as pressed to the
     // inputs channel.  Used to send synthetic releases when input
@@ -336,6 +337,7 @@ impl RyllApp {
             error_message: None,
             mouse_mode: 0,
             last_mouse_pos: None,
+            last_modifiers: None,
             forwarded_buttons: 0,
             pending_resize: None,
             bandwidth: BandwidthTracker::new(byte_counter),
@@ -736,7 +738,6 @@ impl RyllApp {
                     ..
                 } = event
                 {
-                    // F11/F12 are consumed by the traffic viewer / bug report shortcuts
                     if *key == egui::Key::F11 || *key == egui::Key::F12 {
                         continue;
                     }
@@ -746,14 +747,40 @@ impl RyllApp {
                         } else {
                             InputEvent::KeyUp(up_code)
                         };
-                        debug!(
-                            "app: key {:?} pressed={} scancode={:#x}",
-                            key, pressed, down_code
-                        );
                         let _ = input_tx.try_send(ev);
                     }
                 }
             }
+
+            let mods = i.modifiers;
+            let prev = self.last_modifiers.unwrap_or_default();
+
+            if mods.ctrl != prev.ctrl {
+                let code = 0x1D; // Left Ctrl
+                if mods.ctrl {
+                    let _ = input_tx.try_send(InputEvent::KeyDown(code));
+                } else {
+                    let _ = input_tx.try_send(InputEvent::KeyUp(code | 0x80));
+                }
+            }
+            if mods.shift != prev.shift {
+                let code = 0x2A; // Left Shift
+                if mods.shift {
+                    let _ = input_tx.try_send(InputEvent::KeyDown(code));
+                } else {
+                    let _ = input_tx.try_send(InputEvent::KeyUp(code | 0x80));
+                }
+            }
+            if mods.alt != prev.alt {
+                let code = 0x38; // Left Alt
+                if mods.alt {
+                    let _ = input_tx.try_send(InputEvent::KeyDown(code));
+                } else {
+                    let _ = input_tx.try_send(InputEvent::KeyUp(code | 0x80));
+                }
+            }
+
+            self.last_modifiers = Some(mods);
         });
     }
 
@@ -1567,6 +1594,21 @@ impl eframe::App for RyllApp {
                                                 y: pos.1,
                                             });
                                         }
+                                    }
+
+                                    let scroll_y = i.smooth_scroll_delta.y;
+                                    if scroll_y.abs() > 0.5 {
+                                        let btn = if scroll_y > 0.0 { 0x08 } else { 0x10 };
+                                        let _ = tx.try_send(InputEvent::MouseDown {
+                                            button: btn,
+                                            x: pos.0,
+                                            y: pos.1,
+                                        });
+                                        let _ = tx.try_send(InputEvent::MouseUp {
+                                            button: btn,
+                                            x: pos.0,
+                                            y: pos.1,
+                                        });
                                     }
                                 });
                             }

--- a/src/protocol/logging.rs
+++ b/src/protocol/logging.rs
@@ -106,7 +106,15 @@ pub fn hex_dump(data: &[u8], max_bytes: usize) {
 pub mod message_names {
     use super::super::constants::*;
 
-    /// Get main channel server message name
+    fn common_client(msg_type: u16) -> Option<&'static str> {
+        match msg_type {
+            main_client::ACK_SYNC => Some("ack_sync"),
+            main_client::ACK => Some("ack"),
+            main_client::PONG => Some("pong"),
+            _ => None,
+        }
+    }
+
     pub fn main_server(msg_type: u16) -> &'static str {
         match msg_type {
             main_server::MIGRATE => "migrate",
@@ -129,9 +137,6 @@ pub mod message_names {
     /// Get main channel client message name
     pub fn main_client(msg_type: u16) -> &'static str {
         match msg_type {
-            main_client::ACK_SYNC => "ack_sync",
-            main_client::ACK => "ack",
-            main_client::PONG => "pong",
             main_client::MIGRATE_FLUSH_MARK => "migrate_flush_mark",
             main_client::MIGRATE_DATA => "migrate_data",
             main_client::DISCONNECTING => "disconnecting",
@@ -139,7 +144,7 @@ pub mod message_names {
             main_client::AGENT_START => "agent_start",
             main_client::AGENT_DATA => "agent_data",
             main_client::AGENT_TOKEN => "agent_token",
-            _ => "unknown",
+            _ => common_client(msg_type).unwrap_or("unknown"),
         }
     }
 
@@ -186,10 +191,7 @@ pub mod message_names {
     pub fn display_client(msg_type: u16) -> &'static str {
         match msg_type {
             display_client::INIT => "init",
-            display_client::ACK_SYNC => "ack_sync",
-            display_client::ACK => "ack",
-            display_client::PONG => "pong",
-            _ => "unknown",
+            _ => common_client(msg_type).unwrap_or("unknown"),
         }
     }
 
@@ -216,7 +218,7 @@ pub mod message_names {
             inputs_client::MOUSE_POSITION => "mouse_position",
             inputs_client::MOUSE_PRESS => "mouse_press",
             inputs_client::MOUSE_RELEASE => "mouse_release",
-            _ => "unknown",
+            _ => common_client(msg_type).unwrap_or("unknown"),
         }
     }
 
@@ -239,12 +241,7 @@ pub mod message_names {
 
     /// Get cursor channel client message name
     pub fn cursor_client(msg_type: u16) -> &'static str {
-        match msg_type {
-            cursor_client::ACK_SYNC => "ack_sync",
-            cursor_client::ACK => "ack",
-            cursor_client::PONG => "pong",
-            _ => "unknown",
-        }
+        common_client(msg_type).unwrap_or("unknown")
     }
 
     /// Get SpiceVMC/usbredir server message name
@@ -263,10 +260,7 @@ pub mod message_names {
         match msg_type {
             spicevmc_client::DATA => "vmc_data",
             spicevmc_client::COMPRESSED_DATA => "vmc_compressed_data",
-            spicevmc_client::ACK_SYNC => "ack_sync",
-            spicevmc_client::ACK => "ack",
-            spicevmc_client::PONG => "pong",
-            _ => "unknown",
+            _ => common_client(msg_type).unwrap_or("unknown"),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add mouse scroll wheel support
- Add modifier key (Ctrl/Shift/Alt) forwarding to guest
- Fix opcode logging for universal messages across all channels

## Scroll Wheel

Detect `smooth_scroll_delta.y` from egui input, send MOUSE_PRESS + MOUSE_RELEASE pair with button 4 (scroll up) or 5 (scroll down). Matches spice-html5 `handle_mousewheel` behavior.

## Modifier Keys

egui does not emit `Event::Key` for Ctrl/Shift/Alt — they only appear as `i.modifiers` state. Track modifier state changes per frame and send KeyDown/KeyUp with AT scancodes:
- Ctrl: 0x1D / 0x9D
- Shift: 0x2A / 0xAA
- Alt: 0x38 / 0xB8

## Opcode Logging

Extract common client opcodes (pong=3, ack=2, ack_sync=1) into `common_client()` function. All channel-specific `*_client()` name resolvers now fall through to this, preventing "unknown" for universal messages like pong on the inputs channel.