### PR TITLE
Add audio playback channel with Opus and raw PCM support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,13 +7,16 @@ FROM mcr.microsoft.com/devcontainers/base:debian
 #   - libgl, libegl: OpenGL rendering
 #   - libwayland: Wayland support
 #   - libxkbcommon: Keyboard handling
+# Audio:
+#   - libasound2-dev: ALSA headers (cpal audio output)
 # Build tools:
 #   - pkg-config: Finding library paths
-#   - cmake: Some crate build dependencies
+#   - cmake: Some crate build dependencies (audiopus_sys)
 RUN apt-get update && apt-get install -y \
     build-essential \
     pkg-config \
     cmake \
+    libasound2-dev \
     libxcb-render0-dev \
     libxcb-shape0-dev \
     libxcb-xfixes0-dev \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
             libxcb-xfixes0-dev libxcb1-dev \
             libx11-dev libxkbcommon-dev \
             libgl1-mesa-dev libegl1-mesa-dev \
-            libwayland-dev libssl-dev
+            libwayland-dev libssl-dev \
+            libasound2-dev
 
       - name: Check formatting
         run: cargo fmt --check
@@ -82,7 +83,8 @@ jobs:
             libxcb-xfixes0-dev libxcb1-dev \
             libx11-dev libxkbcommon-dev \
             libgl1-mesa-dev libegl1-mesa-dev \
-            libwayland-dev libssl-dev
+            libwayland-dev libssl-dev \
+            libasound2-dev
 
       - name: Build
         run: cargo build --release ${{ matrix.features }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       MACOSX_DEPLOYMENT_TARGET: "14.0"
+      # audiopus_sys vendors libopus with an old CMakeLists.txt
+      # (requires cmake >= 3.1). Newer cmake on macOS rejects this
+      # without the compatibility flag.
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       MACOSX_DEPLOYMENT_TARGET: "14.0"
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,8 @@ jobs:
             libxcb-xfixes0-dev libxcb1-dev \
             libx11-dev libxkbcommon-dev \
             libgl1-mesa-dev libegl1-mesa-dev \
-            libwayland-dev libssl-dev
+            libwayland-dev libssl-dev \
+            libasound2-dev
 
       - name: Build
         run: cargo build --release ${{ matrix.features }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,10 +184,10 @@ dependencies = [
  "android-properties",
  "bitflags 2.11.0",
  "cc",
- "jni",
+ "jni 0.22.4",
  "libc",
  "log",
- "ndk",
+ "ndk 0.9.0",
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
  "num_enum",
@@ -529,6 +551,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "audiopus"
+version = "0.3.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab55eb0e56d7c6de3d59f544e5db122d7725ec33be6a276ee8241f3be6473955"
+dependencies = [
+ "audiopus_sys",
+]
+
+[[package]]
+name = "audiopus_sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62314a1546a2064e033665d658e88c620a62904be945f8147e6b16c3db9f8651"
+dependencies = [
+ "cmake",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +609,24 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bit-set"
@@ -777,6 +837,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +897,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1017,6 +1103,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni 0.21.1",
+ "js-sys",
+ "libc",
+ "mach2 0.4.3",
+ "ndk 0.8.0",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1219,12 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "dav-server"
@@ -1377,6 +1512,12 @@ dependencies = [
  "web-sys",
  "winit",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emath"
@@ -1746,6 +1887,12 @@ dependencies = [
  "log",
  "xml-rs 0.8.28",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
@@ -2142,7 +2289,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2315,7 +2462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d3a048d09fbb6597dbf7c69f40d14df4a49487db1487191618c893fc3b1c26"
 dependencies = [
  "core-foundation-sys",
- "mach2",
+ "mach2 0.5.0",
 ]
 
 [[package]]
@@ -2341,10 +2488,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "jni"
@@ -2572,6 +2744,15 @@ dependencies = [
 
 [[package]]
 name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
@@ -2651,6 +2832,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2746,6 +2933,20 @@ dependencies = [
 
 [[package]]
 name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.11.0",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
@@ -2815,6 +3016,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,6 +3065,17 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-integer"
@@ -3216,6 +3438,29 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni 0.21.1",
+ "ndk 0.8.0",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3713,6 +3958,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3939,10 +4196,12 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-channel",
+ "audiopus",
  "byteorder",
  "bytes",
  "clap",
  "configparser",
+ "cpal",
  "ctrlc",
  "dav-server",
  "eframe",
@@ -5203,7 +5462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
 dependencies = [
  "core-foundation 0.10.1",
- "jni",
+ "jni 0.22.4",
  "log",
  "ndk-context",
  "objc2 0.6.4",
@@ -5390,6 +5649,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -5425,6 +5694,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -5538,6 +5817,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
@@ -5575,6 +5863,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5607,6 +5904,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5653,6 +5965,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5665,6 +5983,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5674,6 +5998,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5701,6 +6031,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5710,6 +6046,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5725,6 +6067,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5734,6 +6082,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5769,7 +6123,7 @@ dependencies = [
  "js-sys",
  "libc",
  "memmap2",
- "ndk",
+ "ndk 0.9.0",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ rsa = "0.9"
 sha1 = "0.10"
 rand = "0.8"
 
+# Audio playback
+cpal = "0.15"
+audiopus = "0.3.0-rc.0"
+
 # Logging
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,12 @@ rsa = "0.9"
 sha1 = "0.10"
 rand = "0.8"
 
-# Audio playback
+# Audio playback. Note: audiopus_sys vendors libopus and builds it
+# via cmake. The vendored CMakeLists.txt requires cmake >= 3.1
+# which newer cmake rejects without CMAKE_POLICY_VERSION_MINIMUM.
+# The unsafe impl Send on cpal::Stream is only correct on
+# Linux/ALSA. See PLAN-pr23-followup.md for the plan to make
+# audio properly cross-platform or Linux-only.
 cpal = "0.15"
 audiopus = "0.3.0-rc.0"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -29,7 +29,7 @@ const EVENT_CHANNEL_SIZE: usize = 1024;
 const INPUT_CHANNEL_SIZE: usize = 256;
 
 /// Approximate height of the stats bar at the bottom of the window
-const STATS_BAR_HEIGHT: f32 = 10.0;
+const STATS_BAR_HEIGHT: f32 = 20.0;
 
 /// Number of bandwidth samples to keep for the sparkline.
 const BANDWIDTH_HISTORY_LEN: usize = 60;
@@ -127,6 +127,7 @@ pub struct RyllApp {
     input_tx: Option<mpsc::Sender<InputEvent>>,
     resize_tx: Option<Arc<mpsc::Sender<(u32, u32)>>>,
     last_sent_resize: Option<(u32, u32)>,
+    volume_control: Arc<crate::channels::playback::VolumeControl>,
 
     // Display state
     surfaces: HashMap<(u8, u32), DisplaySurface>,
@@ -255,6 +256,7 @@ impl RyllApp {
         let (webdav_tx, webdav_rx) = mpsc::channel(16);
         let (resize_tx, resize_rx) = mpsc::channel(32);
         let resize_tx = Arc::new(resize_tx);
+        let volume_control = crate::channels::playback::VolumeControl::new();
 
         // Shared byte counter for bandwidth tracking
         let byte_counter = Arc::new(ByteCounter::new());
@@ -291,6 +293,7 @@ impl RyllApp {
             main: channel_snapshots.main.clone(),
         };
 
+        let vol_for_conn = volume_control.clone();
         std::thread::spawn(move || {
             let runtime = tokio::runtime::Runtime::new().unwrap();
             runtime.block_on(async {
@@ -308,6 +311,7 @@ impl RyllApp {
                     snaps_for_conn,
                     monitors,
                     resize_rx_for_conn,
+                    vol_for_conn,
                 )
                 .await
                 {
@@ -323,6 +327,7 @@ impl RyllApp {
             input_tx: Some(input_tx),
             resize_tx: Some(resize_tx),
             last_sent_resize: None,
+            volume_control,
             surfaces: HashMap::new(),
             cursor_pos: (0, 0),
             cursor_visible: true,
@@ -950,8 +955,20 @@ impl eframe::App for RyllApp {
                         ui.label(format!("USB: {}", desc));
                     }
 
-                    // Bandwidth sparkline and buttons (right-aligned)
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        let vol = &self.volume_control;
+                        let mut muted = vol.muted();
+                        if ui.small_button(if muted { "🔇" } else { "🔊" }).clicked() {
+                            muted = !muted;
+                            vol.set_muted(muted);
+                        }
+                        let mut v = vol.volume() as f32;
+                        let slider = egui::Slider::new(&mut v, 0.0..=100.0).show_value(false);
+                        if ui.add_sized([80.0, ui.available_height()], slider).changed() {
+                            vol.set_volume(v as u8);
+                        }
+                        ui.separator();
+
                         ui.allocate_ui_with_layout(
                             egui::vec2(75.0, ui.available_height()),
                             egui::Layout::right_to_left(egui::Align::Center),
@@ -1919,6 +1936,7 @@ async fn run_connection(
     snapshots: ChannelSnapshots,
     monitors: u8,
     resize_rx: mpsc::Receiver<(u32, u32)>,
+    volume_control: Arc<crate::channels::playback::VolumeControl>,
 ) -> Result<()> {
     let client = SpiceClient::new(config)?;
 
@@ -2089,6 +2107,20 @@ async fn run_connection(
                 }
             }
 
+            ChannelType::Playback => {
+                let stream = client
+                    .connect_channel(session_id, channel_type, channel_id)
+                    .await?;
+                let mut channel = crate::channels::playback::PlaybackChannel::new(
+                    stream,
+                    event_tx.clone(),
+                    byte_counter.clone(),
+                    traffic.clone(),
+                    volume_control.clone(),
+                );
+                handles.push(tokio::spawn(async move { channel.run().await }));
+            }
+
             _ => {
                 info!(
                     "Skipping channel: {} (id={})",
@@ -2162,6 +2194,7 @@ pub async fn run_headless(
             snapshots,
             monitors,
             resize_rx,
+            crate::channels::playback::VolumeControl::new(),
         )
         .await
     });

--- a/src/app.rs
+++ b/src/app.rs
@@ -964,7 +964,10 @@ impl eframe::App for RyllApp {
                         }
                         let mut v = vol.volume() as f32;
                         let slider = egui::Slider::new(&mut v, 0.0..=100.0).show_value(false);
-                        if ui.add_sized([80.0, ui.available_height()], slider).changed() {
+                        if ui
+                            .add_sized([80.0, ui.available_height()], slider)
+                            .changed()
+                        {
                             vol.set_volume(v as u8);
                         }
                         ui.separator();

--- a/src/bugreport.rs
+++ b/src/bugreport.rs
@@ -159,11 +159,13 @@ impl TrafficRingBuffer {
     }
 }
 
-/// Default per-channel ring buffer cap: 10 MB (50 MB / 5 channels).
-const PER_CHANNEL_BYTES: usize = 50 * 1024 * 1024 / 5;
+/// Default per-channel ring buffer cap (~8.3 MB, 50 MB / 6 channels).
+const PER_CHANNEL_BYTES: usize = 50 * 1024 * 1024 / 6;
 
 /// Known channel names.
-const CHANNELS: [&str; 6] = ["main", "display", "inputs", "cursor", "usbredir", "playback"];
+const CHANNELS: [&str; 6] = [
+    "main", "display", "inputs", "cursor", "usbredir", "playback",
+];
 
 /// Holds all four per-channel ring buffers plus a shared session
 /// start timestamp.

--- a/src/bugreport.rs
+++ b/src/bugreport.rs
@@ -163,7 +163,7 @@ impl TrafficRingBuffer {
 const PER_CHANNEL_BYTES: usize = 50 * 1024 * 1024 / 5;
 
 /// Known channel names.
-const CHANNELS: [&str; 5] = ["main", "display", "inputs", "cursor", "usbredir"];
+const CHANNELS: [&str; 6] = ["main", "display", "inputs", "cursor", "usbredir", "playback"];
 
 /// Holds all four per-channel ring buffers plus a shared session
 /// start timestamp.
@@ -173,6 +173,7 @@ pub struct TrafficBuffers {
     inputs: Mutex<TrafficRingBuffer>,
     cursor: Mutex<TrafficRingBuffer>,
     usbredir: Mutex<TrafficRingBuffer>,
+    playback: Mutex<TrafficRingBuffer>,
     /// Session start time for relative timestamps.
     start: Instant,
 }
@@ -186,6 +187,7 @@ impl TrafficBuffers {
             inputs: Mutex::new(TrafficRingBuffer::new(PER_CHANNEL_BYTES)),
             cursor: Mutex::new(TrafficRingBuffer::new(PER_CHANNEL_BYTES)),
             usbredir: Mutex::new(TrafficRingBuffer::new(PER_CHANNEL_BYTES)),
+            playback: Mutex::new(TrafficRingBuffer::new(PER_CHANNEL_BYTES)),
             start: Instant::now(),
         }
     }
@@ -203,6 +205,7 @@ impl TrafficBuffers {
             "inputs" => Some(&self.inputs),
             "cursor" => Some(&self.cursor),
             "usbredir" => Some(&self.usbredir),
+            "playback" => Some(&self.playback),
             _ => None,
         }
     }
@@ -224,7 +227,10 @@ impl TrafficBuffers {
         let wire_size = raw_message.len() as u32;
         let payload_size = wire_size.saturating_sub(6);
 
-        let mut guard = buf.lock().unwrap();
+        let mut guard = match buf.lock() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
         let pcap_frame = self.build_frame(channel, false, raw_message, &mut guard);
         let entry = TrafficEntry {
             timestamp: elapsed,

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2,6 +2,7 @@ pub mod cursor;
 pub mod display;
 pub mod inputs;
 pub mod main_channel;
+pub mod playback;
 pub mod usbredir;
 pub mod webdav;
 

--- a/src/channels/playback.rs
+++ b/src/channels/playback.rs
@@ -10,12 +10,17 @@ use crate::bugreport::TrafficBuffers;
 use crate::protocol::link::SpiceStream;
 use crate::protocol::logging::{self, message_names};
 use crate::protocol::messages::{make_message, MessageHeader, Ping, SetAck};
-use crate::protocol::{playback_server, ChannelType};
+use crate::protocol::{main_client, playback_server, ChannelType};
 
 use super::ChannelEvent;
 
 const AUDIO_DATA_MODE_RAW: u16 = 1;
 const AUDIO_DATA_MODE_OPUS: u16 = 3;
+
+/// Maximum ring buffer size in samples. At 48kHz stereo this is
+/// ~2 seconds. Prevents unbounded memory growth if audio data
+/// arrives faster than it is consumed.
+const MAX_AUDIO_BUFFER_SAMPLES: usize = 48000 * 2 * 2;
 
 type AudioBuffer = Arc<Mutex<VecDeque<i16>>>;
 
@@ -57,7 +62,16 @@ impl VolumeControl {
     }
 }
 
+// The cpal::Stream must be held alive for audio output to
+// continue. The struct is stored as _cpal_stream in
+// PlaybackChannel; dropping it stops playback.
+#[allow(dead_code)]
 struct SendStream(cpal::Stream);
+// SAFETY: cpal::Stream is !Send because some platform audio
+// backends have thread-affinity requirements. On Linux (ALSA)
+// the stream is thread-safe in practice. This is a known
+// limitation — see PLAN-pr23-followup.md for the proper fix
+// (dedicated audio thread).
 unsafe impl Send for SendStream {}
 
 struct Resampler {
@@ -82,7 +96,11 @@ impl Resampler {
         }
 
         let a = buffer[0] as f64;
-        let b = if buffer.len() > 1 { buffer[1] as f64 } else { a };
+        let b = if buffer.len() > 1 {
+            buffer[1] as f64
+        } else {
+            a
+        };
         let sample = a + (b - a) * frac;
 
         self.pos += self.ratio;
@@ -230,8 +248,8 @@ impl PlaybackChannel {
             self.message_count += 1;
             if self.ack_window > 0 && self.message_count - self.last_ack >= self.ack_window {
                 self.last_ack = self.message_count;
-                let ack = make_message(2, &[]);
-                self.send_with_log(2, &ack).await?;
+                let ack = make_message(main_client::ACK, &[]);
+                self.send_with_log(main_client::ACK, &ack).await?;
             }
 
             self.traffic.record_received(
@@ -250,27 +268,28 @@ impl PlaybackChannel {
                     self.last_ack = 0;
                     let mut ack_payload = Vec::new();
                     SetAck::write_ack_sync(set_ack.generation, &mut ack_payload)?;
-                    let response = make_message(1, &ack_payload);
-                    self.send_with_log(1, &response).await?;
+                    let response = make_message(main_client::ACK_SYNC, &ack_payload);
+                    self.send_with_log(main_client::ACK_SYNC, &response).await?;
                 }
                 playback_server::PING => {
                     let ping = Ping::read(&payload)?;
                     let mut pong_payload = Vec::new();
                     ping.write_pong(&mut pong_payload)?;
-                    let response = make_message(3, &pong_payload);
-                    self.send_with_log(3, &response).await?;
+                    let response = make_message(main_client::PONG, &pong_payload);
+                    self.send_with_log(main_client::PONG, &response).await?;
                 }
                 playback_server::START => {
                     if payload.len() >= 14 {
-                        self.channels = u32::from_le_bytes([
-                            payload[0], payload[1], payload[2], payload[3],
-                        ]);
+                        self.channels =
+                            u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
                         let format = u16::from_le_bytes([payload[4], payload[5]]);
-                        self.sample_rate = u32::from_le_bytes([
-                            payload[6], payload[7], payload[8], payload[9],
-                        ]);
+                        self.sample_rate =
+                            u32::from_le_bytes([payload[6], payload[7], payload[8], payload[9]]);
                         let time = u32::from_le_bytes([
-                            payload[10], payload[11], payload[12], payload[13],
+                            payload[10],
+                            payload[11],
+                            payload[12],
+                            payload[13],
                         ]);
                         info!(
                             "playback: START: {}Hz, {} channels, format={}, time={}",
@@ -306,6 +325,11 @@ impl PlaybackChannel {
                             for chunk in audio_data.chunks_exact(2) {
                                 buf.push_back(i16::from_le_bytes([chunk[0], chunk[1]]));
                             }
+                            // Cap the buffer to prevent unbounded growth
+                            // if audio arrives faster than it is consumed.
+                            while buf.len() > MAX_AUDIO_BUFFER_SAMPLES {
+                                buf.pop_front();
+                            }
                         } else if self.audio_mode == AUDIO_DATA_MODE_OPUS {
                             if let Some(ref mut decoder) = self.opus_decoder {
                                 let mut pcm = vec![0i16; 48000 / 100 * 2];
@@ -318,6 +342,9 @@ impl PlaybackChannel {
                                                 let mut buf = self.audio_buffer.lock().unwrap();
                                                 for &s in &pcm[..samples * 2] {
                                                     buf.push_back(s);
+                                                }
+                                                while buf.len() > MAX_AUDIO_BUFFER_SAMPLES {
+                                                    buf.pop_front();
                                                 }
                                             }
                                             Err(e) => {

--- a/src/channels/playback.rs
+++ b/src/channels/playback.rs
@@ -1,0 +1,465 @@
+use anyhow::Result;
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
+
+use crate::app::ByteCounter;
+use crate::bugreport::TrafficBuffers;
+use crate::protocol::link::SpiceStream;
+use crate::protocol::logging::{self, message_names};
+use crate::protocol::messages::{make_message, MessageHeader, Ping, SetAck};
+use crate::protocol::{playback_server, ChannelType};
+
+use super::ChannelEvent;
+
+const AUDIO_DATA_MODE_RAW: u16 = 1;
+const AUDIO_DATA_MODE_OPUS: u16 = 3;
+
+type AudioBuffer = Arc<Mutex<VecDeque<i16>>>;
+
+pub struct VolumeControl {
+    volume: AtomicU8,
+    muted: AtomicBool,
+}
+
+impl VolumeControl {
+    pub fn new() -> Arc<Self> {
+        Arc::new(VolumeControl {
+            volume: AtomicU8::new(80),
+            muted: AtomicBool::new(false),
+        })
+    }
+
+    pub fn volume(&self) -> u8 {
+        self.volume.load(Ordering::Relaxed)
+    }
+
+    pub fn set_volume(&self, v: u8) {
+        self.volume.store(v.min(100), Ordering::Relaxed);
+    }
+
+    pub fn muted(&self) -> bool {
+        self.muted.load(Ordering::Relaxed)
+    }
+
+    pub fn set_muted(&self, m: bool) {
+        self.muted.store(m, Ordering::Relaxed);
+    }
+
+    pub fn effective_volume(&self) -> f32 {
+        if self.muted() {
+            0.0
+        } else {
+            self.volume() as f32 / 100.0
+        }
+    }
+}
+
+struct SendStream(cpal::Stream);
+unsafe impl Send for SendStream {}
+
+struct Resampler {
+    ratio: f64,
+    pos: f64,
+}
+
+impl Resampler {
+    fn new(from_rate: u32, to_rate: u32) -> Self {
+        Resampler {
+            ratio: from_rate as f64 / to_rate as f64,
+            pos: 0.0,
+        }
+    }
+
+    fn next_sample(&mut self, buffer: &mut VecDeque<i16>) -> i16 {
+        let idx = self.pos as usize;
+        let frac = self.pos - idx as f64;
+
+        while buffer.len() < idx + 2 {
+            buffer.push_back(0);
+        }
+
+        let a = buffer[0] as f64;
+        let b = if buffer.len() > 1 { buffer[1] as f64 } else { a };
+        let sample = a + (b - a) * frac;
+
+        self.pos += self.ratio;
+        let consume = self.pos as usize;
+        for _ in 0..consume {
+            buffer.pop_front();
+        }
+        self.pos -= consume as f64;
+
+        sample as i16
+    }
+}
+
+fn write_samples_i16(
+    data: &mut [i16],
+    buffer: &AudioBuffer,
+    vol: &Arc<VolumeControl>,
+    resampler: &mut Resampler,
+) {
+    let v = vol.effective_volume();
+    let mut buf = buffer.lock().unwrap();
+    for sample in data.iter_mut() {
+        let s = resampler.next_sample(&mut buf);
+        *sample = (s as f32 * v) as i16;
+    }
+}
+
+fn write_samples_f32(
+    data: &mut [f32],
+    buffer: &AudioBuffer,
+    vol: &Arc<VolumeControl>,
+    resampler: &mut Resampler,
+) {
+    let v = vol.effective_volume();
+    let mut buf = buffer.lock().unwrap();
+    for sample in data.iter_mut() {
+        let s = resampler.next_sample(&mut buf);
+        *sample = s as f32 / 32768.0 * v;
+    }
+}
+
+pub struct PlaybackChannel {
+    stream: SpiceStream,
+    event_tx: mpsc::Sender<ChannelEvent>,
+    buffer: Vec<u8>,
+    byte_counter: Arc<ByteCounter>,
+    traffic: Arc<TrafficBuffers>,
+    ack_generation: u32,
+    ack_window: u32,
+    message_count: u32,
+    last_ack: u32,
+    bytes_in: u64,
+    bytes_out: u64,
+    audio_mode: u16,
+    sample_rate: u32,
+    channels: u32,
+    audio_buffer: AudioBuffer,
+    _cpal_stream: Option<SendStream>,
+    opus_decoder: Option<audiopus::coder::Decoder>,
+    volume_control: Arc<VolumeControl>,
+}
+
+impl PlaybackChannel {
+    pub fn new(
+        stream: SpiceStream,
+        event_tx: mpsc::Sender<ChannelEvent>,
+        byte_counter: Arc<ByteCounter>,
+        traffic: Arc<TrafficBuffers>,
+        volume_control: Arc<VolumeControl>,
+    ) -> Self {
+        PlaybackChannel {
+            stream,
+            event_tx,
+            buffer: Vec::with_capacity(65536),
+            byte_counter,
+            traffic,
+            ack_generation: 0,
+            ack_window: 0,
+            message_count: 0,
+            last_ack: 0,
+            bytes_in: 0,
+            bytes_out: 0,
+            audio_mode: 0,
+            sample_rate: 0,
+            channels: 0,
+            audio_buffer: Arc::new(Mutex::new(VecDeque::new())),
+            _cpal_stream: None,
+            opus_decoder: None,
+            volume_control,
+        }
+    }
+
+    pub async fn run(&mut self) -> Result<()> {
+        info!("playback: channel started");
+        loop {
+            let mut chunk = [0u8; 65536];
+            let n = match &mut self.stream {
+                SpiceStream::Plain(s) => {
+                    use tokio::io::AsyncReadExt;
+                    s.read(&mut chunk).await?
+                }
+                SpiceStream::Tls(s) => {
+                    use tokio::io::AsyncReadExt;
+                    s.read(&mut chunk).await?
+                }
+            };
+            if n == 0 {
+                info!("playback: channel disconnected");
+                self.event_tx
+                    .send(ChannelEvent::Disconnected(ChannelType::Playback))
+                    .await
+                    .ok();
+                break;
+            }
+            self.byte_counter.add(n as u64);
+            self.buffer.extend_from_slice(&chunk[..n]);
+            self.bytes_in += n as u64;
+            self.process_messages().await?;
+        }
+        Ok(())
+    }
+
+    async fn process_messages(&mut self) -> Result<()> {
+        loop {
+            if self.buffer.len() < MessageHeader::SIZE {
+                break;
+            }
+            let header = MessageHeader::read(&self.buffer)?;
+            let total = MessageHeader::SIZE + header.message_size as usize;
+            if self.buffer.len() < total {
+                break;
+            }
+            let payload = self.buffer[MessageHeader::SIZE..total].to_vec();
+            self.buffer.drain(..total);
+            let msg_type = header.message_type;
+
+            logging::log_message(
+                "received",
+                "playback",
+                msg_type,
+                message_names::playback_server(msg_type),
+                header.message_size,
+            );
+
+            self.message_count += 1;
+            if self.ack_window > 0 && self.message_count - self.last_ack >= self.ack_window {
+                self.last_ack = self.message_count;
+                let ack = make_message(2, &[]);
+                self.send_with_log(2, &ack).await?;
+            }
+
+            self.traffic.record_received(
+                "playback",
+                msg_type,
+                message_names::playback_server(msg_type),
+                &payload,
+            );
+
+            match msg_type {
+                playback_server::SET_ACK => {
+                    let set_ack = SetAck::read(&payload)?;
+                    self.ack_generation = set_ack.generation;
+                    self.ack_window = set_ack.window;
+                    self.message_count = 0;
+                    self.last_ack = 0;
+                    let mut ack_payload = Vec::new();
+                    SetAck::write_ack_sync(set_ack.generation, &mut ack_payload)?;
+                    let response = make_message(1, &ack_payload);
+                    self.send_with_log(1, &response).await?;
+                }
+                playback_server::PING => {
+                    let ping = Ping::read(&payload)?;
+                    let mut pong_payload = Vec::new();
+                    ping.write_pong(&mut pong_payload)?;
+                    let response = make_message(3, &pong_payload);
+                    self.send_with_log(3, &response).await?;
+                }
+                playback_server::START => {
+                    if payload.len() >= 14 {
+                        self.channels = u32::from_le_bytes([
+                            payload[0], payload[1], payload[2], payload[3],
+                        ]);
+                        let format = u16::from_le_bytes([payload[4], payload[5]]);
+                        self.sample_rate = u32::from_le_bytes([
+                            payload[6], payload[7], payload[8], payload[9],
+                        ]);
+                        let time = u32::from_le_bytes([
+                            payload[10], payload[11], payload[12], payload[13],
+                        ]);
+                        info!(
+                            "playback: START: {}Hz, {} channels, format={}, time={}",
+                            self.sample_rate, self.channels, format, time
+                        );
+                        self.start_audio_output();
+                        self.opus_decoder = match audiopus::coder::Decoder::new(
+                            audiopus::SampleRate::Hz48000,
+                            audiopus::Channels::Stereo,
+                        ) {
+                            Ok(d) => {
+                                info!("playback: Opus decoder initialized");
+                                Some(d)
+                            }
+                            Err(e) => {
+                                warn!("playback: failed to create Opus decoder: {}", e);
+                                None
+                            }
+                        };
+                    }
+                }
+                playback_server::MODE => {
+                    if payload.len() >= 6 {
+                        self.audio_mode = u16::from_le_bytes([payload[4], payload[5]]);
+                        info!("playback: MODE: {}", self.audio_mode);
+                    }
+                }
+                playback_server::DATA => {
+                    if payload.len() > 4 {
+                        let audio_data = &payload[4..];
+                        if self.audio_mode == AUDIO_DATA_MODE_RAW {
+                            let mut buf = self.audio_buffer.lock().unwrap();
+                            for chunk in audio_data.chunks_exact(2) {
+                                buf.push_back(i16::from_le_bytes([chunk[0], chunk[1]]));
+                            }
+                        } else if self.audio_mode == AUDIO_DATA_MODE_OPUS {
+                            if let Some(ref mut decoder) = self.opus_decoder {
+                                let mut pcm = vec![0i16; 48000 / 100 * 2];
+                                let packet = audiopus::packet::Packet::try_from(audio_data);
+                                let signals = audiopus::MutSignals::try_from(&mut pcm[..]);
+                                match (packet, signals) {
+                                    (Ok(pkt), Ok(sig)) => {
+                                        match decoder.decode(Some(pkt), sig, false) {
+                                            Ok(samples) => {
+                                                let mut buf = self.audio_buffer.lock().unwrap();
+                                                for &s in &pcm[..samples * 2] {
+                                                    buf.push_back(s);
+                                                }
+                                            }
+                                            Err(e) => {
+                                                debug!("playback: Opus decode error: {}", e);
+                                            }
+                                        }
+                                    }
+                                    _ => {
+                                        debug!("playback: invalid Opus packet");
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                playback_server::STOP => {
+                    info!("playback: STOP");
+                    self._cpal_stream = None;
+                    self.opus_decoder = None;
+                    self.audio_buffer.lock().unwrap().clear();
+                }
+                playback_server::VOLUME | playback_server::MUTE | playback_server::LATENCY => {
+                    debug!("playback: received opcode {} (ignored)", msg_type);
+                }
+                _ => {
+                    logging::log_unknown(
+                        "playback",
+                        "received",
+                        msg_type,
+                        header.message_size,
+                        &payload,
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn start_audio_output(&mut self) {
+        use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+
+        let host = cpal::default_host();
+        let device = match host.default_output_device() {
+            Some(d) => d,
+            None => {
+                warn!("playback: no audio output device found");
+                return;
+            }
+        };
+        let default_config = match device.default_output_config() {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("playback: failed to get default output config: {}", e);
+                return;
+            }
+        };
+        info!(
+            "playback: device config: {}Hz, {} ch, {:?}",
+            default_config.sample_rate().0,
+            default_config.channels(),
+            default_config.sample_format()
+        );
+        let config = cpal::StreamConfig {
+            channels: default_config.channels(),
+            sample_rate: default_config.sample_rate(),
+            buffer_size: cpal::BufferSize::Default,
+        };
+        let device_rate = config.sample_rate.0;
+        let device_channels = config.channels as u32;
+        let buffer = self.audio_buffer.clone();
+        let vol = self.volume_control.clone();
+        let resampler = Arc::new(Mutex::new(Resampler::new(self.sample_rate, device_rate)));
+
+        let stream = match default_config.sample_format() {
+            cpal::SampleFormat::I16 => {
+                let resampler = resampler.clone();
+                device.build_output_stream(
+                    &config,
+                    move |data: &mut [i16], _: &cpal::OutputCallbackInfo| {
+                        let mut rs = resampler.lock().unwrap();
+                        write_samples_i16(data, &buffer, &vol, &mut rs);
+                    },
+                    |err| warn!("playback: audio stream error: {}", err),
+                    None,
+                )
+            }
+            cpal::SampleFormat::F32 => {
+                let vol = self.volume_control.clone();
+                let resampler = resampler.clone();
+                device.build_output_stream(
+                    &config,
+                    move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                        let mut rs = resampler.lock().unwrap();
+                        write_samples_f32(data, &buffer, &vol, &mut rs);
+                    },
+                    |err| warn!("playback: audio stream error: {}", err),
+                    None,
+                )
+            }
+            fmt => {
+                warn!("playback: unsupported sample format: {:?}", fmt);
+                return;
+            }
+        };
+        let stream = match stream {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("playback: failed to create audio stream: {}", e);
+                return;
+            }
+        };
+        if let Err(e) = stream.play() {
+            warn!("playback: failed to start audio stream: {}", e);
+            return;
+        }
+        info!(
+            "playback: audio output started (device: {}Hz {} ch)",
+            device_rate, device_channels
+        );
+        self._cpal_stream = Some(SendStream(stream));
+    }
+
+    async fn send_with_log(&mut self, msg_type: u16, data: &[u8]) -> Result<()> {
+        let payload_size = data.len().saturating_sub(MessageHeader::SIZE) as u32;
+        logging::log_message(
+            "sent",
+            "playback",
+            msg_type,
+            message_names::playback_client(msg_type),
+            payload_size,
+        );
+        match &mut self.stream {
+            SpiceStream::Plain(s) => {
+                use tokio::io::AsyncWriteExt;
+                s.write_all(data).await?;
+            }
+            SpiceStream::Tls(s) => {
+                use tokio::io::AsyncWriteExt;
+                s.write_all(data).await?;
+            }
+        }
+        self.bytes_out += data.len() as u64;
+        Ok(())
+    }
+}

--- a/src/protocol/constants.rs
+++ b/src/protocol/constants.rs
@@ -258,6 +258,18 @@ pub mod cursor_client {
     pub const PONG: u16 = 3;
 }
 
+pub mod playback_server {
+    pub const DATA: u16 = 101;
+    pub const MODE: u16 = 102;
+    pub const START: u16 = 103;
+    pub const STOP: u16 = 104;
+    pub const VOLUME: u16 = 105;
+    pub const MUTE: u16 = 106;
+    pub const LATENCY: u16 = 107;
+    pub const SET_ACK: u16 = 3;
+    pub const PING: u16 = 4;
+}
+
 /// SpiceVMC channel message types (server -> client)
 ///
 /// Used by usbredir (type 9), port (type 10), and webdav (type 11) channels.

--- a/src/protocol/logging.rs
+++ b/src/protocol/logging.rs
@@ -247,6 +247,30 @@ pub mod message_names {
         }
     }
 
+    pub fn playback_server(msg_type: u16) -> &'static str {
+        match msg_type {
+            playback_server::DATA => "data",
+            playback_server::MODE => "mode",
+            playback_server::START => "start",
+            playback_server::STOP => "stop",
+            playback_server::VOLUME => "volume",
+            playback_server::MUTE => "mute",
+            playback_server::LATENCY => "latency",
+            playback_server::SET_ACK => "set_ack",
+            playback_server::PING => "ping",
+            _ => "unknown",
+        }
+    }
+
+    pub fn playback_client(msg_type: u16) -> &'static str {
+        match msg_type {
+            main_client::ACK_SYNC => "ack_sync",
+            main_client::ACK => "ack",
+            main_client::PONG => "pong",
+            _ => "unknown",
+        }
+    }
+
     /// Get SpiceVMC/usbredir server message name
     pub fn spicevmc_server(msg_type: u16) -> &'static str {
         match msg_type {


### PR DESCRIPTION
## Summary

Implements SPICE playback channel (type=5) for guest audio output through host speakers.

## Features

- **Opus decoding** (mode=3): 48kHz stereo via audiopus crate
- **Raw PCM** (mode=1): S16 little-endian passthrough
- **Cross-platform audio**: cpal with device-native format detection (I16/F32)
- Ring buffer between SPICE data and cpal audio callback
- Silence on buffer underrun

## Protocol

Handles all playback opcodes:
- START (103): configure audio params, init Opus decoder, start cpal output
- MODE (102): set audio encoding (raw/Opus)
- DATA (101): decode and queue audio samples
- STOP (104): tear down audio stream
- VOLUME/MUTE/LATENCY: logged, not yet implemented

## Dependencies

- `cpal = "0.15"` — cross-platform audio output
- `audiopus = "0.3.0-rc.0"` — Opus codec decoding