### PR TITLE
Fix auto-reviewer for fork PRs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
   lint:
@@ -151,51 +149,3 @@ jobs:
           name: windows-zip
           path: target/release/ryll-*.zip
           retention-days: 30
-
-  # Check if the last commit was from the bot to prevent infinite loops in
-  # automated fixer jobs. This runs early so other jobs can depend on it.
-  check-bot-commit:
-    name: "Check bot commit"
-    if: github.event_name == 'pull_request'
-    runs-on: [self-hosted, static]
-    outputs:
-      is_bot: ${{ steps.check.outputs.is_bot }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Check if last commit was from bot
-        id: check
-        run: |
-          LAST_AUTHOR_EMAIL=$(git log -1 --format='%ae')
-          echo "Last commit author: $LAST_AUTHOR_EMAIL"
-          if [ "$LAST_AUTHOR_EMAIL" = "bot@shakenfist.com" ]; then
-            echo "is_bot=true" >> $GITHUB_OUTPUT
-            echo "Last commit was from bot - automated fixers will be skipped"
-          else
-            echo "is_bot=false" >> $GITHUB_OUTPUT
-          fi
-
-  automated_reviewer:
-    name: "Automated reviewer"
-    runs-on: [self-hosted, claude-code]
-    needs: [check-bot-commit, lint, build]
-    if: >-
-      ${{ github.event_name == 'pull_request' &&
-          needs.check-bot-commit.outputs.is_bot != 'true' }}
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-reviewer
-      cancel-in-progress: true
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run automated reviewer
-        uses: shakenfist/actions/review-pr-with-claude@main
-        with:
-          pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -1,0 +1,55 @@
+# Automated PR review using Claude Code.
+#
+# Uses pull_request_target so the GITHUB_TOKEN has write access even for
+# fork PRs. This is safe because the review action only reads the diff
+# via `gh pr diff` — it never checks out or executes code from the PR.
+#
+# Template source: shakenfist/development/templates/ci-review-automation/
+
+name: PR Auto-review
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+on:
+  pull_request_target:
+    branches: [develop]
+
+jobs:
+  automated_reviewer:
+    name: "Automated reviewer"
+    runs-on: [self-hosted, claude-code]
+    concurrency:
+      group: pr-auto-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Check if last commit was from bot
+        id: check_bot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LAST_AUTHOR_EMAIL=$(gh api \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" \
+            --jq '.[-1].commit.author.email')
+          echo "Last commit author: $LAST_AUTHOR_EMAIL"
+          if [ "$LAST_AUTHOR_EMAIL" = "bot@shakenfist.com" ]; then
+            echo "is_bot=true" >> $GITHUB_OUTPUT
+            echo "Last commit was from bot - skipping review"
+          else
+            echo "is_bot=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout base branch
+        if: steps.check_bot.outputs.is_bot != 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run automated reviewer
+        if: steps.check_bot.outputs.is_bot != 'true'
+        uses: shakenfist/actions/review-pr-with-claude@main
+        with:
+          pr-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Move the automated reviewer to a separate workflow using pull_request_target so the GITHUB_TOKEN gets write access even for fork PRs. The review action only reads the diff via `gh pr diff` and never executes PR code, so this is safe. Remove the now-orphaned check-bot-commit job and excess write permissions from ci.yml.

Prompt: PR 21 had the auto reviewer fail, please debug.