### PR TITLE
Add plans index, navigation ordering, and template update.

### DIFF
--- a/PLAN-TEMPLATE.md
+++ b/PLAN-TEMPLATE.md
@@ -104,6 +104,22 @@ them.
 This section should list any bugs we encounter during
 development that we fixed.
 
+### Documentation index maintenance
+
+When creating a new master plan from this template, update
+the following files in `docs/plans/`:
+
+* **`index.md`** — add a row to the *Master plans* table
+  with the creation date, a link to the plan, a one-line
+  intent summary, the initial status, and links to each
+  phase plan file. Keep the table in chronological order.
+* **`order.yml`** — add an entry for the new master plan
+  so it appears in the documentation navigation bar. Phase
+  files should *not* be added to `order.yml`.
+
+When all phases of a plan are complete, update the status
+column in `index.md` to *Complete*.
+
 ### Back brief
 
 Before executing any step of this plan, please back brief

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -1,0 +1,32 @@
+# Plans index
+
+This page summarises every planning document in chronological order. Master
+plans decompose work into numbered phases, each with its own detailed plan
+file. Standalone plans track issues, follow-ups, or design decisions that
+do not require phased execution.
+
+## Master plans
+
+| Date | Plan | Intent | Status | Phases |
+|------|------|--------|--------|--------|
+| 2026-04-01 | [Initial porting plan](PLAN-initial.md) | Port the ryll SPICE client from Python to Rust with egui | Complete | (design document) |
+| 2026-04-01 | [Capture mode](PLAN-capture.md) | Protocol traffic pcap and display frame video capture for debugging | Complete | [1. Infrastructure](PLAN-capture-phase-01-infra.md), [2. Pcap](PLAN-capture-phase-02-pcap.md), [3. Video](PLAN-capture-phase-03-video.md) |
+| 2026-04-01 | [Packaging](PLAN-packaging.md) | Cross-platform packaging for Debian, RPM, macOS, and Windows | Complete | [1. Portability](PLAN-packaging-phase-01-portability.md), [2. CI](PLAN-packaging-phase-02-ci.md), [3. Debian](PLAN-packaging-phase-03-debian.md), [4. RPM](PLAN-packaging-phase-04-rpm.md), [5. macOS](PLAN-packaging-phase-05-macos.md), [6. Windows](PLAN-packaging-phase-06-windows.md), [7. Release](PLAN-packaging-phase-07-release.md) |
+| 2026-04-02 | [USB redirection](PLAN-usb-redir.md) | USB device redirection via the SPICE usbredir channel | Complete | [1. VMC channel](PLAN-usb-redir-phase-01-vmc-channel.md), [2. Parser](PLAN-usb-redir-phase-02-usbredir-parser.md), [3. Backend trait](PLAN-usb-redir-phase-03-device-backend.md), [4. Real devices](PLAN-usb-redir-phase-04-real-devices.md), [5. Connect](PLAN-usb-redir-phase-05-device-connect.md), [6. Transfers](PLAN-usb-redir-phase-06-transfers.md), [7. Virtual MSC](PLAN-usb-redir-phase-07-virtual-msc.md), [8. UI](PLAN-usb-redir-phase-08-ui.md), [9. Interrupt](PLAN-usb-redir-phase-09-interrupt.md), [10. Testing](PLAN-usb-redir-phase-10-testing.md) |
+| 2026-04-03 | [Cursor rendering](PLAN-cursor-rendering.md) | Render SPICE server-provided cursor as an egui overlay | Complete | [1. Parse](PLAN-cursor-rendering-phase-01-parse.md), [2. Render](PLAN-cursor-rendering-phase-02-render.md) |
+| 2026-04-04 | [Bug reports](PLAN-bug-reports.md) | Interactive bug reporting with protocol ring buffers and display region selection | Complete | [1. Ring buffer](PLAN-bug-reports-phase-01-ring-buffer.md), [2. Channel state](PLAN-bug-reports-phase-02-channel-state.md), [3. Zip output](PLAN-bug-reports-phase-03-zip-output.md), [4. GUI button](PLAN-bug-reports-phase-04-gui-button.md), [5. Region select](PLAN-bug-reports-phase-05-region-select.md), [6. Traffic viewer](PLAN-bug-reports-phase-06-traffic-viewer.md), [7. Docs](PLAN-bug-reports-phase-07-docs.md) |
+| 2026-04-05 | [USB UI](PLAN-usb-ui.md) | Interactive USB device management panel on the status bar | Complete | [1. Bus fix](PLAN-usb-ui-phase-01-bus-fix.md), [2. Wire tx](PLAN-usb-ui-phase-02-wire-tx.md), [3. Panel](PLAN-usb-ui-phase-03-panel.md), [4. Enumerate](PLAN-usb-ui-phase-04-enumerate.md), [5. Connect](PLAN-usb-ui-phase-05-connect.md), [6. Add disk](PLAN-usb-ui-phase-06-add-disk.md), [7. Polish](PLAN-usb-ui-phase-07-polish.md), [8. Docs](PLAN-usb-ui-phase-08-docs.md) |
+| 2026-04-06 | [WebDAV](PLAN-webdav.md) | WebDAV folder sharing via the SPICE port channel | Complete | [1. Port channel](PLAN-webdav-phase-01-port-channel.md), [2. Mux protocol](PLAN-webdav-phase-02-mux-protocol.md), [3. WebDAV server](PLAN-webdav-phase-03-webdav-server.md), [4. Integration](PLAN-webdav-phase-04-integration.md), [5. UI](PLAN-webdav-phase-05-ui.md), [6. Testing](PLAN-webdav-phase-06-testing.md) |
+| 2026-04-08 | [Crate extraction](PLAN-crate-extraction.md) | Extract compression, protocol, and usbredir crates for reuse | Complete | [1. Workspace](PLAN-crate-extraction-phase-01-workspace.md), [2. Reserve names](PLAN-crate-extraction-phase-02-reserve-names.md), [3. Compression](PLAN-crate-extraction-phase-03-compression.md), [4. Protocol](PLAN-crate-extraction-phase-04-protocol.md), [5. Usbredir](PLAN-crate-extraction-phase-05-usbredir.md), [6. Client](PLAN-crate-extraction-phase-06-client.md) |
+
+## Standalone plans
+
+These plans track issues, follow-ups, or deferred work without phased
+execution.
+
+| Date | Plan | Intent |
+|------|------|--------|
+| 2026-04-01 | [Remaining issues](PLAN-remaining-issues.md) | Outstanding issues after the initial Rust port bring-up |
+| 2026-04-08 | [Display iteration follow-ups](PLAN-display-iteration-followups.md) | Deferred work from display rendering, QUIC decode, and multi-monitor PRs |
+| 2026-04-11 | [PR #20 follow-up](PLAN-pr20-followup.md) | Follow-up fixes from clipboard, MJPEG, and disconnect handling |
+| 2026-04-11 | [PR #23 follow-up](PLAN-pr23-followup.md) | Follow-up fixes from audio playback channel integration |

--- a/docs/plans/order.yml
+++ b/docs/plans/order.yml
@@ -1,0 +1,21 @@
+---
+# This file defines the ordering and page titles for the import of
+# this content into `shakenfist/docs/components/ryll/plans/`. Only
+# master plans and the index are listed here; phase-specific plan
+# files are linked from the index and from each master plan's
+# execution table.
+
+- index.md: Plans index
+- PLAN-initial.md: Initial porting plan
+- PLAN-capture.md: Capture mode
+- PLAN-packaging.md: Packaging
+- PLAN-usb-redir.md: USB redirection
+- PLAN-cursor-rendering.md: Cursor rendering
+- PLAN-bug-reports.md: Bug reports
+- PLAN-usb-ui.md: USB UI
+- PLAN-webdav.md: WebDAV
+- PLAN-crate-extraction.md: Crate extraction
+- PLAN-remaining-issues.md: Remaining issues
+- PLAN-display-iteration-followups.md: Display follow-ups
+- PLAN-pr20-followup.md: PR 20 follow-up
+- PLAN-pr23-followup.md: PR 23 follow-up


### PR DESCRIPTION
Add docs/plans/index.md with a chronological summary table of all master and standalone plans, including phase links. Add docs/plans/order.yml to limit the navigation bar to master plans and the index. Update PLAN-TEMPLATE.md with a new "Documentation index maintenance" section so future plans keep the index and order.yml current.

Prompt: Let's implement an index.md which has a table summarizing in chronological order the intent of each master plan, its status, and a list of its phases (with links to each detailed phase plan). Let's also generate an order.yml like that at shakenfist/cloudgood/docs/order.yml which causes only the master plans to be in the navigation bar. Also update PLAN-TEMPLATE.md to ensure we keep this maintained in the future.



Assisted-By: Claude Code