### PR TITLE
Add REVIEW-STATE-TEMPLATE.md for paused reviews.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,7 @@ ryll/src/
 
 ## Process templates
 
-Three templates at the repo root capture the workflows we
+Four templates at the repo root capture the workflows we
 use repeatedly. Read the template before starting one of
 these activities so the resulting plan/PR follows the
 established structure.
@@ -246,6 +246,12 @@ established structure.
   Wave 0, prompt-injection sub-agent, and a mandatory
   follow-up plan that lands as our own PR immediately
   after the contributor's merge.
+- **`REVIEW-STATE-TEMPLATE.md`** — skeleton for the local-
+  only `REVIEW-STATE.md` file that lives in each
+  external-PR review's worktree. Captures findings,
+  branch state, contributor history, plan B, and a
+  "How to resume" entry point for picking the work back
+  up after a pause. Never committed.
 
 ## Testing
 

--- a/MERGE-TEMPLATE.md
+++ b/MERGE-TEMPLATE.md
@@ -52,11 +52,25 @@ The guiding principles for merging external PRs:
    findings as PR comments and giving them a round. Where
    history shows they don't iterate, land and follow up.
    This is a per-PR operator call (see Step 0).
+6. **Preserve state across pauses.** External-PR reviews
+   often involve waiting — for CI, for the contributor to
+   respond, for our own bandwidth. Each review maintains a
+   local-only `REVIEW-STATE.md` in its worktree (copied
+   from `REVIEW-STATE-TEMPLATE.md`) so that returning to
+   the work after a pause does not require reconstructing
+   findings, branch layout, or next actions from scratch.
+   The state file is never committed; it is for our future
+   selves only. A state file that is not kept up to date
+   becomes misleading archaeology — worse than no file at
+   all — so update it whenever the situation changes.
 
 ## Process overview
 
 ```
 Step 0: Operator sets the teachy level for this PR
+        Assistant copies REVIEW-STATE-TEMPLATE.md into
+        the worktree as REVIEW-STATE.md and starts
+        filling it in
    │
    ▼
 Step 1: Operator does a first-pass read (already done
@@ -87,9 +101,13 @@ Step 7: Operator runs CI on the PR
    ▼
 Step 8: Operator merges, then our follow-up PR goes in
         immediately after
+
+Throughout: REVIEW-STATE.md is updated whenever a step
+            completes, an action is taken on the PR, the
+            contributor responds, or CI returns a result.
 ```
 
-## Step 0: Teachy level
+## Step 0: Teachy level and state file
 
 Before doing any review work, the assistant asks the
 operator which teaching posture to adopt for this PR. The
@@ -102,10 +120,13 @@ Options:
   follow-up plan. Default when the contributor has
   repeatedly declined to iterate.
 - **Light** — post findings as a single PR comment, give
-  the contributor one iteration round with a short timebox
-  (e.g. one week). If they don't respond or their response
-  is partial, proceed with land-and-follow-up for the
-  remainder. Default for a new contributor.
+  the contributor a chance to address the blocking items.
+  Prefer vague urgency ("take whatever time you need")
+  over hard deadlines — vague urgency tends to produce
+  better engagement than ultimatums. If the contributor
+  doesn't engage in a reasonable time (operator judgment),
+  fall back to land-and-follow-up for the remainder.
+  Default for a new contributor.
 - **Full** — iterate as long as the contributor engages.
   Only appropriate when the contributor has demonstrated
   they will respond to feedback and make changes. Rare.
@@ -113,6 +134,15 @@ Options:
 The assistant should ask once at the start, record the
 answer, and default to "none" only when the operator
 confirms that's appropriate for this contributor.
+
+Also at Step 0, the assistant copies
+`REVIEW-STATE-TEMPLATE.md` from the repo root into the
+review's worktree as `REVIEW-STATE.md` and starts filling
+in the PR identity, teachy mode, and contributor history
+sections. The state file is a living document that gets
+updated through the rest of the review (see "Throughout"
+in the process overview). It must not be staged or
+committed — it is for our future selves only.
 
 ## Step 2: Wave 0 — deterministic scanners
 
@@ -435,17 +465,51 @@ Once CI passes and triage is complete:
 3. Assistant is available for CI babysitting if needed
    (see `/loop` skill) but does not open the PR.
 
+## Step 9: Maintain `REVIEW-STATE.md`
+
+Not really a single step — `REVIEW-STATE.md` is a living
+document that gets updated throughout the review. Specific
+moments where it must be updated:
+
+- **At Step 0**, after the teachy mode is decided and the
+  template is copied in.
+- **After each Wave** (0, 1, 2) finishes, with the
+  findings classified.
+- **After the triage decision in Step 5**, with the final
+  blocking / should / nice / informational lists.
+- **After any action on the PR** — pre-merge fixes pushed,
+  PR comments posted, force-pushes, etc.
+- **After CI returns** — pass or fail, with what failed
+  if relevant.
+- **When the contributor responds** — what they said and
+  what we plan to do.
+- **When picking the work back up** after time away — to
+  capture what changed while we were gone.
+
+The "How to resume" section at the top of the state file
+is the entry point for future-you (or future-assistant).
+Keep it accurate — if the resume steps would be different
+now, update them.
+
+The state file is local-only, never staged. Treat it like
+a working notebook: high churn, low ceremony, only useful
+if kept current.
+
 ## Management session checklist
 
 Before declaring the merge process complete:
 
 - [ ] Step 0: teachy level recorded.
+- [ ] Step 0: `REVIEW-STATE.md` created in the worktree
+      from the template.
 - [ ] Wave 0 deterministic scanners run and results
       triaged.
 - [ ] Wave 1 LLM safety review complete.
 - [ ] Wave 2 LLM quality review complete.
 - [ ] All findings classified (blocking / follow-up /
       teach / ignore).
+- [ ] `REVIEW-STATE.md` reflects the current findings,
+      branch state, and next actions.
 - [ ] Blocking findings fixed on the contributor's branch
       with the smallest possible patch.
 - [ ] Teach findings posted as a PR comment (if teachy
@@ -458,3 +522,6 @@ Before declaring the merge process complete:
 - [ ] Our follow-up PR opened immediately after.
 - [ ] PR 23 → PR 28 pattern preserved: one PR for theirs,
       one immediately after for ours.
+- [ ] `REVIEW-STATE.md` either deleted (if the worktree
+      is being torn down) or updated to a "complete"
+      state (if the worktree is staying for a while).

--- a/REVIEW-STATE-TEMPLATE.md
+++ b/REVIEW-STATE-TEMPLATE.md
@@ -1,0 +1,189 @@
+# PR NN review state
+
+This file is local-only — never staged, never committed,
+never pushed. It captures the state of a single external
+PR review so that returning to the worktree later does not
+require reconstructing context from scratch.
+
+Copy this template into the review's worktree as
+`REVIEW-STATE.md` at the start of a review (after Step 0
+of `MERGE-TEMPLATE.md`), then keep it updated as you work.
+A state file that does not get updated becomes misleading
+archaeology — worse than no file at all.
+
+## How to resume
+
+When picking this work back up after time away (operator
+prompt to assistant: "we're back in `<worktree>`, read
+`REVIEW-STATE.md` first then check what's happened
+since"), do these in order:
+
+1. Read this file end-to-end.
+2. `git fetch origin` and `git fetch <contributor-remote>`
+   to refresh refs.
+3. `git log origin/develop..<contributor-remote>/<branch>
+   --oneline` to see if the contributor pushed anything
+   since our last action.
+4. `gh pr view NN --comments` to read any new comments
+   from the contributor or other reviewers.
+5. `gh pr checks NN` to see CI status. If CI failed,
+   investigate against the blocking findings listed
+   below.
+6. Cross-check that develop has not moved in a way that
+   invalidates an earlier rebase or our findings: `git log
+   <our-last-action-sha>..origin/develop -- <files we
+   touched or care about>`. Anything substantive there
+   may mean re-rebasing or reassessing.
+7. Decide next action based on what you found:
+   - **Contributor engaged and pushed fixes**: re-run
+     a Wave 2 review pass on the new commits, look for
+     regressions, decide whether to merge.
+   - **Contributor commented but not pushed**: respond
+     to whatever they said.
+   - **Silence + CI passing**: judgment call on whether
+     to wait longer or fall back to plan B (see below).
+   - **CI failing**: figure out why and decide whether
+     to fix on the contributor's branch (preserves
+     authorship) or wait for them.
+8. Update this file with anything you've learned.
+
+## PR
+
+- **Repo**: <owner>/<repo>
+- **Number**: NN
+- **Title**: <PR title>
+- **Contributor**: <github-handle> (<full name if known>)
+- **Head branch**: <contributor-remote>/<branch> (note
+  whether `maintainerCanModify` is true — affects whether
+  we can push to their branch)
+- **Last contributor commit before our actions**: <sha>
+- **Our latest action commit on contributor branch**:
+  <sha or "none">
+- **Local branch tracking our work**: <branch>
+
+## Teachy mode
+
+Set per Step 0 of `MERGE-TEMPLATE.md`. One of:
+
+- **None** — land-and-followup. No PR comments to the
+  contributor. All non-blocking findings become our own
+  follow-up plan.
+- **Light** — post findings as a single PR comment, give
+  the contributor a chance. Vague urgency tends to work
+  better than hard deadlines.
+- **Full** — iterate as long as the contributor engages.
+
+Record the choice and the reason for it. If history with
+this contributor changes the choice, note that too.
+
+## What was done
+
+A bullet list of actions we have taken on this review,
+in chronological order. Examples:
+
+- Followed `MERGE-TEMPLATE.md` Wave 0 → Wave 1 → Wave 2.
+- Rebased onto develop using "develop wins unless PR is
+  genuinely better" strategy. Rationale in merge commit
+  <sha>.
+- Force-pushed rebase to <contributor-remote>/<branch>.
+- Posted review comment: <link to PR comment>.
+- Other actions as taken.
+
+## What is left
+
+### PR's unique value still pending
+
+After any rebase / our actions, what does this PR still
+uniquely contribute that develop does not have? List in
+priority order. This is the "is it worth landing?"
+calculus made explicit.
+
+- <item> (severity / value)
+- <item>
+- ...
+
+### Findings posted (or to post)
+
+Findings from Wave 1 and Wave 2 reviews, classified per
+Step 5 of `MERGE-TEMPLATE.md`. Summarise here so future-
+you can scan without re-reading the PR comment.
+
+**Blocking** (would ship a regression or fail CI):
+
+1. <finding>
+2. <finding>
+
+**Should-have** (we'd like to see, happy to discuss):
+
+1. <finding>
+2. <finding>
+
+**Nice-to-have** (small things, please if convenient):
+
+1. <finding>
+2. <finding>
+
+**Informational** (not requesting changes, just noting):
+
+- <finding>
+- <finding>
+
+## Branches in this worktree
+
+- **<branch>** (currently checked out) — <description>
+- **<branch>** — <description>
+
+## Other worktrees relevant to this work
+
+If other worktrees were created in service of this review
+(e.g. for parallel work on follow-up plans, or for related
+PRs), list them here so future-you knows where to look.
+
+- **<worktree>** — <purpose, current state>
+
+## When CI returns
+
+Document the expected outcomes and what to do for each:
+
+- **CI passes**: <action>
+- **CI fails**: <expected failure modes and how to debug>
+  - The two blocking findings most likely to cause
+    failures are <finding 1> and <finding 2>.
+
+## Plan B (if the contributor doesn't engage)
+
+When teachy mode is light or full, plan B is the fallback
+if the contributor stops responding. Spell it out
+explicitly so future-you can execute without rederiving:
+
+1. Apply the N blocking fixes ourselves on a new branch
+   off <base>.
+2. <Push location and method>.
+3. Write follow-up plan in
+   `docs/plans/PLAN-prNN-followup.md` tracking
+   should-have, nice-to-have, and informational items.
+4. Land the PR with our pre-merge fixes (note any
+   Co-Authored-By attribution that should appear).
+5. Open follow-up PR using
+   `docs/plans/PLAN-prNN-followup.md` as the work list.
+
+If you previously drafted the pre-merge fixes on a branch
+and then dropped that branch, note that here so future-you
+knows the work needs re-deriving (and where the
+instructions live — usually the posted PR comment).
+
+## Don't forget
+
+A grab-bag of things that are easy to forget when
+returning to this work:
+
+- New CI gates that landed on develop while we were
+  waiting (cargo audit, cargo deny, etc.) and that this
+  PR has to pass.
+- Cross-repo implications (e.g. kerbside docs that
+  reference protocol behaviour this PR changes).
+- Any previously-recorded follow-up items in
+  `PLAN-supply-chain-followups.md` or similar that this
+  PR interacts with.
+- Anything else specific to this PR that does not fit
+  cleanly elsewhere.


### PR DESCRIPTION
External-PR reviews involve waiting — for CI, for the contributor to respond, for our own bandwidth. Coming back to a paused review currently requires reconstructing findings, branch layout, and next actions from scratch, which is wasteful and error-prone.

Introduce REVIEW-STATE-TEMPLATE.md as the skeleton for a local-only REVIEW-STATE.md that lives in each external PR review's worktree. The template covers PR identity, teachy mode, what was done, what is left (split into unique value still pending and findings classified per MERGE-TEMPLATE Step 5), branch state, plan B if the contributor stops engaging, and a "How to resume" section that drives the operator+assistant prompt for picking the work back up.

Update MERGE-TEMPLATE.md throughout to describe how REVIEW-STATE.md fits into the workflow:

- Add a sixth philosophy principle covering state preservation across pauses.
- Extend the process overview with a "Throughout" line noting that the state file is updated whenever the situation changes.
- Extend Step 0 to explicitly include copying the template into the worktree alongside the teachy-mode decision.
- Add a Step 9 covering the specific moments the state file must be updated, the role of the "How to resume" section as the entry point, and the never-commit rule.
- Soften the Step 0 light-teachy guidance from a hard "one week" timebox to vague urgency, which we have found produces better contributor engagement than ultimatums.
- Add state-file checkpoints to the management session checklist.

Update AGENTS.md "Process templates" section to list the fourth template alongside PLAN, PUSH, and MERGE.

Prompt: I think let's be as descriptive as possible in MERGE-TEMPLATE.md.