### PR TITLE
Split release flow into propose and tag phases.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,15 +31,15 @@ help:
 	@echo "  make propose-release X.Y.Z  - Branch, bump versions, push for PR review"
 	@echo "  make tag-release X.Y.Z      - After PR merge: tag develop, trigger release"
 	@echo "  make test                   - Run tests"
-	@echo "  make lint           - Run rustfmt and clippy checks"
-	@echo "  make lint-fix       - Run rustfmt and clippy with auto-fix"
-	@echo "  make devcontainer   - Build the development container"
-	@echo "  make clean          - Remove build artifacts"
+	@echo "  make lint                   - Run rustfmt and clippy checks"
+	@echo "  make lint-fix               - Run rustfmt and clippy with auto-fix"
+	@echo "  make devcontainer           - Build the development container"
+	@echo "  make clean                  - Remove build artifacts"
 	@echo ""
 	@echo "Test SPICE server:"
-	@echo "  make test-qemu      - Start a QEMU instance with SPICE on port $(QEMU_SPICE_PORT)"
-	@echo "  make test-qemu-usb  - Same, with USB redirection enabled"
-	@echo "  make test-qemu-stop - Stop the test QEMU instance"
+	@echo "  make test-qemu              - Start a QEMU instance with SPICE on port $(QEMU_SPICE_PORT)"
+	@echo "  make test-qemu-usb          - Same, with USB redirection enabled"
+	@echo "  make test-qemu-stop         - Stop the test QEMU instance"
 
 # Build the devcontainer image
 devcontainer:

--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,19 @@ QEMU_VARS_COPY := /tmp/ryll-test-ovmf-vars.fd
 UID := $(shell id -u)
 GID := $(shell id -g)
 
-.PHONY: all build release publish clean clean-testdata devcontainer ensure-cache \
-	lint lint-fix test help test-qemu test-qemu-usb test-qemu-stop
+.PHONY: all build release propose-release tag-release clean clean-testdata \
+	devcontainer ensure-cache lint lint-fix test help \
+	test-qemu test-qemu-usb test-qemu-stop
 
 all: build
 
 help:
 	@echo "Ryll build targets:"
-	@echo "  make build          - Build debug version"
-	@echo "  make release        - Build release version"
-	@echo "  make publish X.Y.Z  - Cut a release: bump versions, tag, push"
-	@echo "  make test           - Run tests"
+	@echo "  make build                  - Build debug version"
+	@echo "  make release                - Build release version"
+	@echo "  make propose-release X.Y.Z  - Branch, bump versions, push for PR review"
+	@echo "  make tag-release X.Y.Z      - After PR merge: tag develop, trigger release"
+	@echo "  make test                   - Run tests"
 	@echo "  make lint           - Run rustfmt and clippy checks"
 	@echo "  make lint-fix       - Run rustfmt and clippy with auto-fix"
 	@echo "  make devcontainer   - Build the development container"
@@ -82,20 +84,38 @@ release: ensure-cache
 		$(RYLL_IMAGE) \
 		cargo build --release -p ryll
 
-# Cut a release: bump versions, commit, tag, push. Takes the version as a
-# positional arg: `make publish 0.1.4`. The second word of MAKECMDGOALS is
-# the version; the no-op rules below catch X.Y.Z-shaped goals so make does
-# not complain about "no rule to make target 0.1.4".
+# Cutting a release is a two-phase operation so the version bump
+# goes through the normal PR review gate rather than landing
+# directly on develop.
+#
+# Phase 1: `make propose-release X.Y.Z` creates a release-X.Y.Z
+# branch off develop, bumps the workspace version, pushes the
+# branch, and prints the PR creation URL.
+#
+# Phase 2: after the PR merges, `make tag-release X.Y.Z` tags
+# the resulting commit on develop and pushes the tag, which
+# triggers .github/workflows/release.yml.
+#
+# The second word of MAKECMDGOALS is the version; the no-op
+# rules below catch X.Y.Z-shaped goals so make does not
+# complain about "no rule to make target 0.1.4".
 RELEASE_VERSION := $(word 2,$(MAKECMDGOALS))
-publish:
+propose-release:
 	@if [ -z "$(RELEASE_VERSION)" ]; then \
-		echo "usage: make publish X.Y.Z"; exit 1; \
+		echo "usage: make propose-release X.Y.Z"; exit 1; \
 	fi
-	./tools/cut-release.sh $(RELEASE_VERSION)
+	./tools/propose-release.sh $(RELEASE_VERSION)
 
-# Absorb a version-shaped second word as a no-op target. This only matches
-# X.Y.Z numeric forms, so typos in real targets still fail loudly.
-ifneq ($(filter publish,$(MAKECMDGOALS)),)
+tag-release:
+	@if [ -z "$(RELEASE_VERSION)" ]; then \
+		echo "usage: make tag-release X.Y.Z"; exit 1; \
+	fi
+	./tools/tag-release.sh $(RELEASE_VERSION)
+
+# Absorb a version-shaped second word as a no-op target. This only
+# matches X.Y.Z numeric forms, so typos in real targets still fail
+# loudly.
+ifneq ($(filter propose-release tag-release,$(MAKECMDGOALS)),)
 $(RELEASE_VERSION):
 	@:
 endif

--- a/docs/plans/PLAN-crate-release.md
+++ b/docs/plans/PLAN-crate-release.md
@@ -44,32 +44,62 @@ from ryll.
 
 ### Release-cutting workflow
 
-New script [tools/cut-release.sh](../../tools/cut-release.sh), invoked
-as `make publish 0.1.4`. The script:
+The cut is split into two phases so the version bump goes through
+the same PR review gate as every other change, rather than landing
+directly on `develop`.
+
+**Phase 1** — [tools/propose-release.sh](../../tools/propose-release.sh),
+invoked as `make propose-release 0.1.4`. The script:
 
 1. Parses and validates the version argument as `X.Y.Z`.
-2. Verifies git: on `develop` (the repository default branch),
-   working tree clean, up to date with `origin/develop`.
-3. Verifies the tag `v0.1.4` does not already exist locally or on
-   `origin`.
+2. Verifies git: on `develop`, working tree clean, in sync with
+   `origin/develop`.
+3. Verifies neither the tag `v0.1.4` nor the branch
+   `release-0.1.4` already exists locally or on `origin`.
 4. Verifies crates.io does not already have `0.1.4` for any of the
    four crates (HTTP GET to the crates.io API — 404 means free).
-5. Runs `pre-commit run --all-files`.
-6. Runs `cargo release version 0.1.4 --workspace --execute --no-confirm`
+5. Creates and switches to `release-0.1.4`.
+6. Runs `pre-commit run --all-files`.
+7. Runs `cargo release version 0.1.4 --workspace --execute --no-confirm`
    to bump `[workspace.package].version` and the path-dep
    `version =` qualifiers in one pass.
-7. Runs `cargo test --workspace` as a final gate.
-8. Shows `git diff --stat`, then prompts "Release v0.1.4? [y/N]".
-9. On `y`: creates the release commit, pushes it, creates an
-   annotated tag `v0.1.4`, pushes the tag (this is what triggers
+8. Runs `cargo test --workspace` as a final gate.
+9. Shows `git diff --stat`, then prompts
+   "Commit and push release-0.1.4? [y/N]".
+10. On `y`: commits `Release 0.1.4.` and pushes
+    `release-0.1.4` to `origin`. On `n`: switches back to
+    `develop` and deletes the release branch — nothing reaches
+    `origin`.
+11. Prints the PR-creation URL so the operator can open the PR
+    manually. The script never creates PRs itself (per the
+    repository convention that PR creation stays with the
+    operator).
+
+**Phase 2** — [tools/tag-release.sh](../../tools/tag-release.sh),
+invoked as `make tag-release 0.1.4` after the phase-1 PR has been
+merged. The script:
+
+1. Fetches `origin/develop` and the latest tags.
+2. Verifies no `v0.1.4` tag exists locally or on `origin`.
+3. Reads `[workspace.package].version` from `origin/develop` and
+   checks it is `0.1.4`; bails otherwise (means the PR has not
+   merged yet or a different version landed).
+4. Shows the target SHA and subject line, spells out that pushing
+   the tag will publish all four crates to crates.io irreversibly,
+   and prompts "Create and push tag v0.1.4? [y/N]".
+5. On `y`: creates an annotated tag `v0.1.4` at the fetched
+   `origin/develop` SHA and pushes it (this is what triggers
    [release.yml](../../.github/workflows/release.yml)).
-10. Runs `gh run watch` on the triggered workflow, then
-    `gh release view v0.1.4 --web` once it completes.
+6. Runs `gh run watch` on the triggered workflow, then
+   `gh release view v0.1.4 --web` once it completes.
 
 `cargo-release` is installed on the host (not inside Docker). It is
 a pure Rust CLI and does not interact with the project's toolchain;
 running it on the host is simpler than the alternative because the
-script also needs git, gh, and SSH key access.
+scripts also need git, gh, and SSH key access. Hosts running older
+rustc (e.g. Debian's cargo 1.85) should pin
+`cargo-release@0.25.18`, which is the last release that supports
+1.85.
 
 ### Release workflow (release.yml)
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,7 +1,22 @@
 # Releasing
 
-Releases are cut via [tools/cut-release.sh](../tools/cut-release.sh)
-(wrapped by `make publish X.Y.Z`) and finished by GitHub Actions.
+Cutting a release is a two-phase operation so the version bump
+goes through the normal PR review gate rather than landing
+directly on `develop`:
+
+1. **Phase 1 — propose:**
+   [tools/propose-release.sh](../tools/propose-release.sh)
+   (wrapped by `make propose-release X.Y.Z`) creates a
+   `release-X.Y.Z` branch from `develop`, bumps the workspace
+   version, runs tests, and pushes the branch. You open a PR
+   from it into `develop` and get it reviewed and merged like
+   any other change.
+2. **Phase 2 — tag:** after the PR has merged,
+   [tools/tag-release.sh](../tools/tag-release.sh) (wrapped by
+   `make tag-release X.Y.Z`) fetches `develop`, verifies its
+   tip has the expected workspace version, creates an annotated
+   `vX.Y.Z` tag at that commit, and pushes the tag.
+
 The tag push triggers
 [.github/workflows/release.yml](../.github/workflows/release.yml),
 which:
@@ -52,49 +67,83 @@ Two secrets must be configured in the ryll repo settings:
   update step fails; the GitHub Release and crates.io publishes
   still succeed.
 
-### Host tools (for `make publish`)
+### Host tools
 
-`make publish` runs `tools/cut-release.sh` on the operator's
-host (not in a container). The script requires:
+Both scripts run on the operator's host (not in a container).
+Between them they require:
 
 - `cargo-release` — `cargo install --locked cargo-release`.
-  Used for the workspace-wide version bump.
-- `gh` — the GitHub CLI, signed in (`gh auth login`). Used to
-  watch the release workflow and open the release page on
-  completion.
+  Used for the workspace-wide version bump in phase 1. If your
+  host toolchain is older than 1.91 (for example Debian's
+  packaged cargo 1.85), pin the last version that supports it:
+  `cargo install --locked cargo-release@0.25.18`.
+- `gh` — the GitHub CLI, signed in (`gh auth login`). Used in
+  phase 2 to watch the release workflow and open the release
+  page on completion.
 - `jq`, `curl`, `git`, `pre-commit` — standard dev tooling.
 
 ## Release process
 
-From a clean checkout of the current default branch (`develop`):
+### Phase 1: propose the release
+
+From a clean checkout of `develop`, up to date with origin:
 
 ```bash
-make publish 0.2.0
+make propose-release 0.2.0
 ```
 
 The script will:
 
 1. Validate the version as `X.Y.Z`.
-2. Confirm the working tree is clean, the branch is up to date
-   with origin, and `v0.2.0` does not yet exist locally or on
-   origin.
+2. Confirm the working tree is clean, the branch is `develop`
+   and in sync with `origin/develop`, and neither `v0.2.0` nor
+   `release-0.2.0` exist locally or on origin.
 3. Query crates.io for `0.2.0` on all four crates; bail if any
    already exists.
-4. Run `pre-commit run --all-files`.
-5. Bump `[workspace.package].version` and the matching
+4. Create and switch to `release-0.2.0`.
+5. Run `pre-commit run --all-files`.
+6. Bump `[workspace.package].version` and the matching
    `version =` qualifiers on ryll's path dependencies via
    `cargo release version 0.2.0 --workspace --execute
    --no-confirm`.
-6. Run `cargo test --workspace`.
-7. Show `git diff --stat` and prompt `Release v0.2.0? [y/N]`.
-8. On confirmation: create `Release 0.2.0.`, push, tag
-   `v0.2.0` (annotated), push the tag.
-9. Watch the release workflow via `gh run watch` and open the
-   release page when it completes.
+7. Run `cargo test --workspace`.
+8. Show `git diff --stat` and prompt
+   `Commit and push release-0.2.0? [y/N]`.
+9. On confirmation: commit `Release 0.2.0.` and push
+   `release-0.2.0` to origin.
 
-Nothing irreversible happens before the `y/N` prompt. If you
-answer `N`, the working tree will be left with uncommitted
-version bumps; revert with `git checkout -- .`.
+Nothing goes to origin before the `y/N` prompt. If you answer
+`N`, the script switches back to `develop` and deletes the
+release branch; nothing is committed.
+
+Once the script finishes, open a PR from `release-0.2.0` into
+`develop`, get it reviewed, and merge it using the repository's
+usual merge strategy. No release artefacts are produced yet —
+this PR is the audit trail for the version bump itself.
+
+### Phase 2: tag the merged commit
+
+After the PR has merged:
+
+```bash
+make tag-release 0.2.0
+```
+
+The script will:
+
+1. Fetch `origin/develop` and the latest tags.
+2. Verify no `v0.2.0` tag exists locally or on origin.
+3. Verify the `[workspace.package].version` on
+   `origin/develop` is `0.2.0` (i.e. the release PR has
+   landed). If it still reports the previous version, the PR
+   has not merged yet — the script bails.
+4. Show the target SHA and subject line, spell out that
+   pushing the tag will publish all four crates to crates.io
+   irreversibly, and prompt `Create and push tag v0.2.0? [y/N]`.
+5. On confirmation: create the annotated tag at
+   `origin/develop` and push it.
+6. Watch the triggered release workflow via `gh run watch` and
+   open the GitHub Release page when it completes.
 
 ## Artifacts produced
 
@@ -113,14 +162,17 @@ version bumps; revert with `git checkout -- .`.
 The `check-version` job reads `[workspace.package].version`
 from the root `Cargo.toml` and compares it to the tag. A
 mismatch fails the workflow and files a GitHub issue. This
-should not happen when you release via `make publish`, since
-the script bumps and tags from a single version string. If it
-does (for example after a manual tag push):
+should not happen when you release via the `propose-release`
+→ `tag-release` flow, since `tag-release` refuses to run
+unless `origin/develop` already carries the matching
+workspace version. If it does (for example after a manual tag
+push):
 
 ```bash
 git tag -d v0.2.0
 git push origin :refs/tags/v0.2.0
-# fix the workspace version, commit, then re-tag via make publish
+# fix the workspace version on develop via a new release PR,
+# then re-run make tag-release X.Y.Z.
 ```
 
 ### crates.io publish fails

--- a/tools/propose-release.sh
+++ b/tools/propose-release.sh
@@ -1,23 +1,29 @@
 #!/bin/bash
 #
-# Cut a release of the ryll workspace.
+# Propose a release of the ryll workspace.
 #
-# Bumps the workspace version to the one given on the command line,
-# runs tests, and (after confirmation) commits, tags, and pushes.
-# The push of the tag triggers .github/workflows/release.yml, which
-# builds binaries, publishes the four workspace crates to crates.io,
-# creates a GitHub Release, and updates the Homebrew tap.
+# Creates a `release-X.Y.Z` branch from develop, bumps the workspace
+# version, runs the test suite, and (after confirmation) commits and
+# pushes the branch. Does NOT open a PR and does NOT tag — both of
+# those happen outside the script:
+#
+#   1. Run this script.
+#   2. Open a PR from release-X.Y.Z to develop, get it reviewed
+#      and merged like any other change.
+#   3. Run tools/tag-release.sh X.Y.Z to tag the merge commit on
+#      develop and push the tag (that is what triggers
+#      .github/workflows/release.yml).
 #
 # Usage:
-#   tools/cut-release.sh VERSION
-#   make publish VERSION
+#   tools/propose-release.sh VERSION
+#   make propose-release VERSION
 #
 # Example:
-#   make publish 0.1.4
+#   make propose-release 0.1.4
 #
 # Requirements on the host:
 #   - cargo-release:  cargo install --locked cargo-release
-#   - gh CLI:         for watching the release workflow
+#     (or cargo install --locked cargo-release@0.25.18 on rustc 1.85)
 #   - curl, jq:       for querying crates.io
 
 set -euo pipefail
@@ -41,13 +47,12 @@ VERSION="$1"
     || err "version must be X.Y.Z, got: $VERSION"
 
 TAG="v$VERSION"
+RELEASE_BRANCH="release-$VERSION"
 
 # --- tool availability ---
 
 command -v cargo-release >/dev/null \
     || err "cargo-release not installed. Run: cargo install --locked cargo-release"
-command -v gh >/dev/null \
-    || err "gh CLI not installed"
 command -v jq >/dev/null || err "jq not installed"
 
 # --- working directory must be repo root ---
@@ -79,6 +84,13 @@ if git ls-remote --tags --exit-code origin "$TAG" >/dev/null 2>&1; then
     err "tag $TAG already exists on origin"
 fi
 
+if git rev-parse --verify "$RELEASE_BRANCH" >/dev/null 2>&1; then
+    err "branch $RELEASE_BRANCH already exists locally"
+fi
+if git ls-remote --heads --exit-code origin "$RELEASE_BRANCH" >/dev/null 2>&1; then
+    err "branch $RELEASE_BRANCH already exists on origin"
+fi
+
 # --- crates.io version availability ---
 
 info "Checking crates.io for existing $VERSION"
@@ -96,6 +108,24 @@ for crate in "${CRATES[@]}"; do
         *)   err "unexpected HTTP $code checking $crate $VERSION" ;;
     esac
 done
+
+# --- create release branch ---
+
+info "Creating branch $RELEASE_BRANCH from develop"
+git switch -c "$RELEASE_BRANCH"
+
+# Ensure we clean up the branch if the script aborts after this
+# point without a successful push.
+CLEANUP_BRANCH=1
+cleanup() {
+    if [[ "${CLEANUP_BRANCH:-0}" == "1" ]]; then
+        info "Cleaning up: switching back to develop and deleting $RELEASE_BRANCH"
+        git checkout -- . 2>/dev/null || true
+        git switch develop 2>/dev/null || true
+        git branch -D "$RELEASE_BRANCH" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
 
 # --- pre-commit ---
 
@@ -118,45 +148,35 @@ cargo test --workspace
 # --- confirmation ---
 
 echo
-echo "About to release $TAG. Pending changes:"
+echo "About to propose release $VERSION on branch $RELEASE_BRANCH."
+echo "Pending changes:"
 git diff --stat
 echo
-read -rp "Release $TAG? [y/N] " REPLY
+read -rp "Commit and push $RELEASE_BRANCH? [y/N] " REPLY
 [[ "$REPLY" =~ ^[Yy]$ ]] || {
-    info "Aborted. Version bumps left uncommitted; revert with: git checkout -- ."
+    info "Aborted at confirmation."
     exit 1
 }
 
-# --- commit, tag, push ---
+# --- commit and push ---
 
-info "Creating release commit"
+info "Creating release proposal commit"
 git add -u
 git commit -m "Release ${VERSION}."
 
-info "Creating annotated tag $TAG"
-git tag -a "$TAG" -m "Release $VERSION"
+info "Pushing $RELEASE_BRANCH"
+git push --set-upstream origin "$RELEASE_BRANCH"
 
-info "Pushing develop"
-git push origin develop
+# Successful push — disable cleanup so we leave the user on the
+# release branch for PR creation.
+CLEANUP_BRANCH=0
 
-info "Pushing tag $TAG (this triggers the release workflow)"
-git push origin "$TAG"
-
-# --- watch the workflow ---
-
-info "Waiting for release workflow to start"
-sleep 5
-RUN_ID=$(gh run list \
-    --workflow=release.yml \
-    --limit 1 \
-    --json databaseId \
-    --jq '.[0].databaseId')
-
-if [[ -n "$RUN_ID" ]]; then
-    info "Watching workflow run $RUN_ID"
-    gh run watch "$RUN_ID" || info "workflow did not complete cleanly"
-    info "Opening release page"
-    gh release view "$TAG" --web || true
-else
-    info "Could not find workflow run. Check manually: gh run list --workflow=release.yml"
-fi
+echo
+info "Release proposed on branch $RELEASE_BRANCH."
+echo
+echo "Next steps:"
+echo "  1. Open a PR from $RELEASE_BRANCH into develop:"
+echo "     https://github.com/shakenfist/ryll/pull/new/$RELEASE_BRANCH"
+echo "  2. Get it reviewed and merged."
+echo "  3. Run 'make tag-release $VERSION' to tag develop and"
+echo "     trigger the release workflow."

--- a/tools/tag-release.sh
+++ b/tools/tag-release.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+#
+# Tag and push a release of the ryll workspace.
+#
+# Meant to be run after the release-X.Y.Z PR produced by
+# tools/propose-release.sh has been reviewed and merged into develop.
+# Fetches origin/develop, verifies its tip has the expected workspace
+# version, and (after confirmation) creates an annotated tag vX.Y.Z
+# pointing at that commit and pushes it. Pushing the tag triggers
+# .github/workflows/release.yml, which builds binaries, publishes
+# the four workspace crates to crates.io, creates a GitHub Release,
+# and updates the Homebrew tap.
+#
+# Usage:
+#   tools/tag-release.sh VERSION
+#   make tag-release VERSION
+#
+# Example:
+#   make tag-release 0.1.4
+#
+# Requirements on the host:
+#   - gh CLI: for watching the release workflow
+#   - jq:     for parsing gh output
+
+set -euo pipefail
+
+err() { echo "error: $*" >&2; exit 1; }
+info() { echo "==> $*"; }
+
+# --- arg parsing ---
+
+[[ $# -eq 1 ]] || err "usage: $0 VERSION (e.g. 0.1.4)"
+VERSION="$1"
+
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+    || err "version must be X.Y.Z, got: $VERSION"
+
+TAG="v$VERSION"
+
+# --- tool availability ---
+
+command -v gh >/dev/null || err "gh CLI not installed"
+command -v jq >/dev/null || err "jq not installed"
+
+# --- working directory must be repo root ---
+
+cd "$(dirname "$0")/.."
+[[ -f Cargo.toml ]] || err "could not find repo root"
+
+# --- fetch latest develop ---
+
+info "Fetching origin"
+git fetch origin develop --tags --quiet
+
+# --- tag must not already exist ---
+
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+    err "tag $TAG already exists locally"
+fi
+if git ls-remote --tags --exit-code origin "$TAG" >/dev/null 2>&1; then
+    err "tag $TAG already exists on origin"
+fi
+
+# --- verify workspace version on origin/develop ---
+
+info "Verifying [workspace.package].version on origin/develop"
+WORKSPACE_TOML=$(git show origin/develop:Cargo.toml)
+ACTUAL=$(printf '%s\n' "$WORKSPACE_TOML" | awk '
+    /^\[workspace\.package\]/ { in_wp=1; next }
+    /^\[/ { in_wp=0 }
+    in_wp && /^version *= */ {
+        gsub(/version *= *"|"/, "")
+        print
+        exit
+    }
+')
+
+[[ -n "$ACTUAL" ]] \
+    || err "could not read [workspace.package].version from origin/develop"
+[[ "$ACTUAL" == "$VERSION" ]] \
+    || err "origin/develop workspace version is $ACTUAL, expected $VERSION. Has the release-$VERSION PR been merged?"
+
+TARGET_SHA=$(git rev-parse origin/develop)
+TARGET_SUBJECT=$(git log -1 --format=%s origin/develop)
+
+# --- confirmation ---
+
+echo
+echo "About to tag $TAG at $TARGET_SHA on origin/develop:"
+echo "  $TARGET_SUBJECT"
+echo
+echo "Pushing this tag will trigger the release workflow:"
+echo "  - build binaries on Linux / macOS / Windows"
+echo "  - publish all four crates to crates.io (IRREVERSIBLE)"
+echo "  - create the GitHub Release"
+echo "  - update the Homebrew tap"
+echo
+read -rp "Create and push tag $TAG? [y/N] " REPLY
+[[ "$REPLY" =~ ^[Yy]$ ]] || {
+    info "Aborted."
+    exit 1
+}
+
+# --- tag and push ---
+
+info "Creating annotated tag $TAG"
+git tag -a "$TAG" -m "Release $VERSION" "$TARGET_SHA"
+
+info "Pushing tag $TAG (this triggers the release workflow)"
+git push origin "$TAG"
+
+# --- watch the workflow ---
+
+info "Waiting for release workflow to start"
+sleep 5
+RUN_ID=$(gh run list \
+    --workflow=release.yml \
+    --limit 1 \
+    --json databaseId \
+    --jq '.[0].databaseId')
+
+if [[ -n "$RUN_ID" ]]; then
+    info "Watching workflow run $RUN_ID"
+    gh run watch "$RUN_ID" || info "workflow did not complete cleanly"
+    info "Opening release page"
+    gh release view "$TAG" --web || true
+else
+    info "Could not find workflow run. Check manually: gh run list --workflow=release.yml"
+fi


### PR DESCRIPTION
Replace the single `make publish X.Y.Z` / cut-release.sh action with a two-phase flow so the version bump goes through the normal PR review gate rather than landing directly on develop.

`make propose-release X.Y.Z` runs tools/propose-release.sh (renamed from cut-release.sh) to create a release-X.Y.Z branch from develop, bump the workspace version, run tests, and push the branch. The operator opens a PR manually and gets it reviewed and merged. Nothing goes to origin until the confirmation prompt.

`make tag-release X.Y.Z` runs the new tools/tag-release.sh after the PR has merged. It fetches origin/develop, verifies the tip carries the expected [workspace.package].version (bailing if the PR has not merged yet), then creates an annotated vX.Y.Z tag at that commit and pushes it. The tag push triggers release.yml, which publishes the four crates to crates.io irreversibly — so the confirmation prompt spells that out.

Also call out the cargo-release@0.25.18 pin for hosts running rustc older than 1.91 (Debian's packaged cargo 1.85) in both docs/releasing.md and the plan doc.

Prompt: Yes please. Keep working in shakenfist/ryll-wt-crate-release for this work so I can send it as a clean PR.