### PR TITLE
Resync Cargo.lock with ryll libc dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4303,6 +4303,7 @@ dependencies = [
  "hyper-util",
  "image",
  "jpeg-decoder",
+ "libc",
  "lz4_flex",
  "mp4",
  "nusb",


### PR DESCRIPTION
Ryll's Cargo.toml declares libc as a direct dependency but the lockfile on develop is missing the corresponding entry under the ryll stanza's dependency list — the line was dropped during a merge. `cargo check --workspace --offline` adds it back deterministically with no other changes.

Without this resync, anyone running cargo on develop sees a dirty Cargo.lock on first build, and the propose-release script's "working tree clean" check would trip on it.

Prompt: Could you please spin up a another branch for the one line cargo.lock fix and send if off?