### PR TITLE
ci: build arm64 binaries on Linux and Windows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,17 +50,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Linux
+          - name: Linux (x86_64)
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             features: ""
-          - name: macOS
+          - name: Linux (aarch64)
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            features: ""
+          - name: macOS (aarch64)
             os: macos-latest
             target: aarch64-apple-darwin
             features: ""
-          - name: Windows
+          - name: Windows (x86_64)
             os: windows-latest
             target: x86_64-pc-windows-msvc
+            features: "--no-default-features"
+          - name: Windows (aarch64)
+            os: windows-11-arm
+            target: aarch64-pc-windows-msvc
             features: "--no-default-features"
     runs-on: ${{ matrix.os }}
     env:
@@ -129,7 +137,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v4
         with:
-          name: deb-package
+          name: deb-package-${{ matrix.target }}
           path: target/debian/*.deb
           retention-days: 30
 
@@ -145,7 +153,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v4
         with:
-          name: rpm-package
+          name: rpm-package-${{ matrix.target }}
           path: target/generate-rpm/*.rpm
           retention-days: 30
 
@@ -175,7 +183,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v4
         with:
-          name: windows-zip
+          name: windows-zip-${{ matrix.target }}
           path: target/release/ryll-*.zip
           retention-days: 30
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,17 +72,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Linux
+          - name: Linux (x86_64)
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             features: ""
-          - name: macOS
+          - name: Linux (aarch64)
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            features: ""
+          - name: macOS (aarch64)
             os: macos-latest
             target: aarch64-apple-darwin
             features: ""
-          - name: Windows
+          - name: Windows (x86_64)
             os: windows-latest
             target: x86_64-pc-windows-msvc
+            features: "--no-default-features"
+          - name: Windows (aarch64)
+            os: windows-11-arm
+            target: aarch64-pc-windows-msvc
             features: "--no-default-features"
     runs-on: ${{ matrix.os }}
     env:
@@ -146,7 +154,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v4
         with:
-          name: release-deb
+          name: release-deb-${{ matrix.target }}
           path: target/debian/*.deb
 
       - name: Install cargo-generate-rpm
@@ -161,7 +169,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v4
         with:
-          name: release-rpm
+          name: release-rpm-${{ matrix.target }}
           path: target/generate-rpm/*.rpm
 
       # --- macOS: tarball ---
@@ -193,7 +201,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v4
         with:
-          name: release-windows
+          name: release-windows-${{ matrix.target }}
           path: target/release/ryll-*.zip
 
   publish-crates:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -548,15 +548,18 @@ applies to all future webrtc-rs work:
 - Cargo cache persisted in `.cargo-cache/` for faster rebuilds
 - **Pre-commit hooks** for code quality (rustfmt, clippy, shellcheck)
 - **GitHub Actions CI** (`.github/workflows/ci.yml`) builds and tests
-  on Linux, macOS (ARM), and Windows on every push to `develop` and
-  on pull requests. CI runs native `cargo` (not Docker). On Linux, CI
-  installs `libopus-dev` so audiopus_sys dynamic-links libopus and the
-  `.deb` declares `libopus0` via cargo-deb's `$auto`; on macOS and
-  Windows audiopus_sys source-builds libopus for a self-contained
-  binary. CI also runs `tools/web-smoke.sh` (plain + `--tls` variants)
-  on Linux to verify `--web` mode startup and graceful shutdown. PRs
-  also receive an automated code review via the shared
-  `shakenfist/actions/review-pr-with-claude` action.
+  on Linux (x86_64 + aarch64), macOS (Apple Silicon), and Windows
+  (x86_64 + aarch64) on every push to `develop` and on pull requests.
+  Each architecture uses a native github-hosted runner (no
+  cross-compile); arm64 Linux uses `ubuntu-24.04-arm` and arm64
+  Windows uses `windows-11-arm`. CI runs native `cargo` (not Docker).
+  On Linux, CI installs `libopus-dev` so audiopus_sys dynamic-links
+  libopus and the `.deb` declares `libopus0` via cargo-deb's `$auto`;
+  on macOS and Windows audiopus_sys source-builds libopus for a
+  self-contained binary. CI also runs `tools/web-smoke.sh` (plain +
+  `--tls` variants) on Linux to verify `--web` mode startup and
+  graceful shutdown. PRs also receive an automated code review via
+  the shared `shakenfist/actions/review-pr-with-claude` action.
 - **Bot-triggered workflows** for PR automation:
   `@shakenfist-bot please re-review`, `please address comments`,
   `please retest`

--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ Pre-built `.deb` packages for Debian/Ubuntu are available from
 
 ## CI and Automation
 
-GitHub Actions CI builds and tests ryll on Linux, macOS (Apple Silicon),
-and Windows on every push to `develop` and on pull requests. PRs also
-receive an automated code review via Claude Code.
+GitHub Actions CI builds and tests ryll on Linux (x86_64 + aarch64),
+macOS (Apple Silicon), and Windows (x86_64 + aarch64) on every push to
+`develop` and on pull requests. PRs also receive an automated code
+review via Claude Code.
 
 Workflows in `.github/workflows/`:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,10 +6,11 @@ and as CI artifacts on pull requests.
 
 ## Debian / Ubuntu
 
-Download the `.deb` package for your architecture and install:
+Download the `.deb` package for your architecture and install. Both
+`amd64` and `arm64` builds are published:
 
 ```bash
-sudo dpkg -i ryll_0.1.0-1_amd64.deb
+sudo dpkg -i ryll_0.1.0-1_amd64.deb   # or ryll_0.1.0-1_arm64.deb
 sudo apt-get install -f   # install any missing dependencies
 ```
 
@@ -19,10 +20,11 @@ The package installs `ryll` to `/usr/bin/ryll`. Runtime dependencies
 
 ## Red Hat / Fedora (RPM)
 
-Download the `.rpm` package for your architecture and install:
+Download the `.rpm` package for your architecture and install. Both
+`x86_64` and `aarch64` builds are published:
 
 ```bash
-sudo dnf install ./ryll-0.1.0-1.x86_64.rpm
+sudo dnf install ./ryll-0.1.0-1.x86_64.rpm   # or ryll-0.1.0-1.aarch64.rpm
 ```
 
 Or with older `yum`-based systems:
@@ -64,9 +66,10 @@ cp ryll /usr/local/bin/
 
 ## Windows
 
-Download the `.zip` archive from
-[GitHub Releases](https://github.com/shakenfist/ryll/releases),
-extract it, and run `ryll.exe`:
+Download the `.zip` archive for your architecture from
+[GitHub Releases](https://github.com/shakenfist/ryll/releases)
+(both `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc` are
+published), extract it, and run `ryll.exe`:
 
 ```powershell
 Expand-Archive ryll-x86_64-pc-windows-msvc.zip -DestinationPath .


### PR DESCRIPTION
Expand the CI and release workflow matrices to add native github-hosted arm64 runners — ubuntu-24.04-arm for aarch64 Linux and windows-11-arm for aarch64 Windows — alongside the existing x86_64 builds. macOS already builds for Apple Silicon and remains arm64-only (Intel macOS is intentionally skipped). Artifact upload names gain a ${matrix.target} suffix so the new builds do not collide with the existing ones; the release.yml github-release job already globs by file pattern after merge-multiple, so the per-arch deb/rpm/tarball/zip files flow through unchanged.

README, AGENTS.md, and docs/installation.md are updated to describe the new arch coverage and to note that both amd64 and arm64 deb/rpm/zip artifacts are now published.

Prompt: Make CI builds produce arm64 binaries for every OS where the upstream platform supports it (Linux, macOS, Windows), in addition to the existing amd64 binaries. Skip Intel macOS.


Assisted-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>