### PR TITLE
chore(deps): group RustCrypto digest-ecosystem crates.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,19 @@
         "digest"
       ],
       "automerge": false
+    },
+    {
+      "description": "Group RustCrypto digest-ecosystem crates so they upgrade in lockstep. The `digest` trait crate is shared by sha*, hmac, rsa, signature, etc., and a major bump of one (e.g. sha1 0.10 -> 0.11 moves to digest 0.11) breaks compilation against any sibling still on the old `digest` major. Keeping them in one PR forces them to land together.",
+      "matchPackageNames": [
+        "digest",
+        "hmac",
+        "md-5",
+        "rsa",
+        "sha1",
+        "sha2",
+        "signature"
+      ],
+      "groupName": "rustcrypto digest ecosystem"
     }
   ],
   "minimumReleaseAge": "3 days",


### PR DESCRIPTION
The previous bump on this branch upgraded sha1 0.10 -> 0.11 in isolation, which broke compilation: sha1 0.11 moved onto digest 0.11, but rsa 0.9 still depends on digest 0.10. The Oaep::new call in shakenfist-spice-protocol/src/link.rs then failed because the Sha1 type's Digest/DynDigest impls came from the wrong major version of digest.

Drop the standalone sha1 bump and add a Renovate package rule that groups digest, sha1, sha2, md-5, hmac, rsa, and signature into one PR. These crates all share the digest trait crate, so a major bump of any one of them must land alongside the others to keep them on a single digest major.

Prompt: PR #73 (renovate sha1 0.10 -> 0.11) failed CI because rsa 0.9 is still on digest 0.10 while sha1 0.11 has moved to digest 0.11, leaving Oaep::new::<Sha1>() unsatisfiable. Land a commit on this PR that reverts the bump and adds the right Renovate grouping so the digest-ecosystem crates upgrade together; we will then monitor the PR until upstream releases let it pass CI.


Assisted-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>