### PR TITLE
deny: allow bzip2-1.0.6 license for libbz2-rs-sys.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,10 @@ allow = [
     "0BSD",
     "CDLA-Permissive-2.0",
     "OFL-1.1",
+    # Pulled in by libbz2-rs-sys (pure-Rust libbz2 port) via
+    # bzip2 -> zip 8.x. Permissive BSD-style licence, safe for
+    # redistribution.
+    "bzip2-1.0.6",
 ]
 confidence-threshold = 0.93
 


### PR DESCRIPTION
The zip 8.x upgrade in PR #84 switches from the C bzip2-sys bindings to the pure-Rust libbz2-rs-sys port, which declares the bzip2-1.0.6 SPDX licence. That identifier is not in our allowlist, so cargo-deny fails the supply chain check.

bzip2-1.0.6 is the permissive BSD-style "bzip2 and libbzip2 Licence v1.0.6" and is safe for our redistribution use. Add it to the licence allowlist with a short note pointing at the dependency that pulls it in.

Prompt: Investigate the cargo lock failures on the zip 8.x renovate PR. After identifying the failure as a cargo-deny licence rejection for bzip2-1.0.6 (declared by libbz2-rs-sys via zip 8.x), allow that licence in deny.toml so the supply-chain check passes and the PR can land. Commit and push on the deps branch so PR #84 can rebase and be merged.


Assisted-By: Claude Opus 4.7 (1M context, medium effort)