### PR TITLE
renovate: pin sha1/rand/rand_core until rsa 0.10 ships.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,27 @@
         "signature"
       ],
       "groupName": "rustcrypto digest ecosystem"
+    },
+    {
+      "description": "Hold sha1 < 0.11 until rsa 0.10 stable releases. sha1 0.11 moves to digest 0.11, but our transitive rsa 0.9 still requires digest 0.10, so Sha1 no longer satisfies rsa::Oaep::new's DynDigest bound. Tracked in shakenfist/ryll#93 / RustCrypto/RSA#647.",
+      "matchPackageNames": [
+        "sha1"
+      ],
+      "allowedVersions": "<0.11"
+    },
+    {
+      "description": "Hold rand < 0.9 until rsa 0.10 stable releases. rand 0.9 restructured CryptoRngCore, which rsa 0.9 calls through. Tracked in shakenfist/ryll#93 / RustCrypto/RSA#647.",
+      "matchPackageNames": [
+        "rand"
+      ],
+      "allowedVersions": "<0.9"
+    },
+    {
+      "description": "Hold rand_core < 0.10 to stay aligned with the rand 0.8 / rsa 0.9 pin above. Tracked in shakenfist/ryll#93 / RustCrypto/RSA#647.",
+      "matchPackageNames": [
+        "rand_core"
+      ],
+      "allowedVersions": "<0.10"
     }
   ],
   "minimumReleaseAge": "3 days",


### PR DESCRIPTION
sha1 0.11 and rand 0.9 cannot land while our transitive rsa 0.9 still uses digest 0.10 and the older rand_core trait set. Both PRs (#76 sha1, #52 rand) were closed; without these caps Renovate immediately reopens them.

Add three allowedVersions caps:

  * sha1   < 0.11
  * rand   < 0.9
  * rand_core < 0.10

Each rule's description points at shakenfist/ryll#93, which tracks the upstream rsa 0.10 release (RustCrypto/RSA#647) and calls for these caps to be removed once rsa 0.10 lands. The existing "rustcrypto digest ecosystem" group rule will then produce a single coordinated bump of rsa / sha1 / rand.

Prompt: After closing the two RustCrypto PRs and filing the upstream tracking issue (#93), add the corresponding Renovate caps so the PRs do not keep reopening.


Assisted-By: Claude Opus 4.7 (1M context, medium effort) <noreply@anthropic.com>