### PR TITLE
fix(main): demote main-channel heartbeat log to debug.

### DIFF
--- a/shakenfist-spice-renderer/src/channels/main_channel.rs
+++ b/shakenfist-spice-renderer/src/channels/main_channel.rs
@@ -575,7 +575,7 @@ impl MainChannel {
                         .map(|d| d.as_millis() as u64)
                         .unwrap_or(0);
                     last_heartbeat_ms.store(now_ms, std::sync::atomic::Ordering::Relaxed);
-                    info!(
+                    debug!(
                         "main: heartbeat T+{:.1}s iter={} last_arm={} last_recv={:?} \
                          last_send={:?} keepalives={} pongs={}",
                         self.traffic.elapsed().as_secs_f64(),


### PR DESCRIPTION
The per-tick heartbeat line on the main channel runs on a fixed timer and produces a steady drip of INFO output that crowds out more useful messages during dogfooding. Demote to DEBUG so it stays available under RUST_LOG=debug but does not appear at the default verbosity.

Prompt: Mikal flagged the recurring "main: heartbeat T+..." INFO line as noisy during testing and asked for it to be moved to debug.


Assisted-By: Claude Opus 4.7 (1M context, medium effort)