### PR TITLE
display: per-stream MJPEG diagnostics in bug reports.

### DIFF
--- a/ryll/src/bugreport.rs
+++ b/ryll/src/bugreport.rs
@@ -25,7 +25,7 @@ use shakenfist_spice_renderer::traffic::TrafficSink;
 #[allow(unused_imports)]
 pub use shakenfist_spice_renderer::snapshots::{
     ChannelSnapshots, CursorCacheEntry, CursorSnapshot, DecodeResult, DisplaySnapshot,
-    InputEventRecord, InputsSnapshot, MainSnapshot,
+    InputEventRecord, InputsSnapshot, MainSnapshot, StreamSnapshot,
 };
 
 /// Direction of a protocol message.
@@ -1919,6 +1919,31 @@ mod tests {
             decode_duration_us: 1234,
         });
         snap.recent_ack_intervals_secs.push_back(0.42);
+        // Stream-diagnostics fields: one active MJPEG stream
+        // exercising every per-stream counter so the
+        // serialiser is locked in to the field names a bug
+        // report will expose.
+        snap.streams_active.push(StreamSnapshot {
+            stream_id: 38,
+            surface_id: 0,
+            codec_type: 1,
+            stream_width: 1600,
+            stream_height: 1200,
+            dest_top: 0,
+            dest_left: 0,
+            dest_bottom: 1200,
+            dest_right: 1600,
+            created_at_secs: 12.5,
+            frames_received: 240,
+            frames_decoded_ok: 200,
+            frames_decode_failed: 40,
+            last_frame_ts_secs: Some(45.5),
+            last_decode_ok_ts_secs: Some(45.4),
+            last_decode_duration_us: 18_321,
+        });
+        snap.streams_created_total = 2;
+        snap.streams_destroyed_total = 1;
+        snap.stream_data_orphan_count = 3;
         let json = serde_json::to_string_pretty(&snap).unwrap();
         assert!(json.contains("\"image_cache_entries\": 3"));
         assert!(json.contains("\"image_type\": \"GlzRgb\""));
@@ -1939,6 +1964,22 @@ mod tests {
         assert!(json.contains("\"recent_ack_intervals_secs\""));
         // Phase-02 field.
         assert!(json.contains("\"writer_dropped_count\": 11"));
+        // Stream-diagnostics fields. The presence of these in the
+        // serialised display channel state is what lets a bug
+        // report answer "did MJPEG frames arrive / decode / paint?".
+        assert!(json.contains("\"streams_active\""));
+        assert!(json.contains("\"stream_id\": 38"));
+        assert!(json.contains("\"codec_type\": 1"));
+        assert!(json.contains("\"stream_width\": 1600"));
+        assert!(json.contains("\"frames_received\": 240"));
+        assert!(json.contains("\"frames_decoded_ok\": 200"));
+        assert!(json.contains("\"frames_decode_failed\": 40"));
+        assert!(json.contains("\"last_frame_ts_secs\": 45.5"));
+        assert!(json.contains("\"last_decode_ok_ts_secs\": 45.4"));
+        assert!(json.contains("\"last_decode_duration_us\": 18321"));
+        assert!(json.contains("\"streams_created_total\": 2"));
+        assert!(json.contains("\"streams_destroyed_total\": 1"));
+        assert!(json.contains("\"stream_data_orphan_count\": 3"));
     }
 
     #[test]

--- a/shakenfist-spice-renderer/src/channels/display.rs
+++ b/shakenfist-spice-renderer/src/channels/display.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 use tokio::sync::{mpsc, Notify};
 use tracing::{debug, error, info, warn};
 
-use crate::snapshots::{DecodeResult, DisplaySnapshot};
+use crate::snapshots::{DecodeResult, DisplaySnapshot, StreamSnapshot};
 use crate::{
     ByteCounter, CaptureSink, LogConfig, NotificationEntry, NotificationSource, TrafficSink,
 };
@@ -136,11 +136,23 @@ pub(crate) fn decode_mjpeg_frame(data: &[u8]) -> Option<(Vec<u8>, u32, u32)> {
 struct StreamState {
     surface_id: u32,
     codec_type: u8,
+    stream_width: u32,
+    stream_height: u32,
     dest_top: u32,
     dest_left: u32,
     dest_bottom: u32,
     dest_right: u32,
     cached_dht: Option<Vec<u8>>,
+    /// Session-relative seconds at `STREAM_CREATE`.
+    created_at_secs: f64,
+    /// Counters mirrored into `StreamSnapshot` by `update_snapshot`.
+    /// See snapshot field docs for semantics.
+    frames_received: u64,
+    frames_decoded_ok: u64,
+    frames_decode_failed: u64,
+    last_frame_ts_secs: Option<f64>,
+    last_decode_ok_ts_secs: Option<f64>,
+    last_decode_duration_us: u32,
 }
 
 /// Maximum number of recent decode results to keep in the snapshot.
@@ -604,6 +616,13 @@ pub struct DisplayChannel {
     /// writer task's queue. Mirrored into
     /// `DisplaySnapshot::writer_dropped_count`.
     capture_dropped_count: u64,
+    /// Stream-channel diagnostics mirrored into
+    /// `DisplaySnapshot::streams_created_total` etc. Added so a
+    /// bug report can answer "did MJPEG frames reach blit?"
+    /// without the user enabling debug logging.
+    streams_created_total: u64,
+    streams_destroyed_total: u64,
+    stream_data_orphan_count: u64,
 }
 
 impl DisplayChannel {
@@ -660,6 +679,9 @@ impl DisplayChannel {
             last_ack_send_ts_secs: None,
             recent_ack_intervals_secs: VecDeque::new(),
             capture_dropped_count: 0,
+            streams_created_total: 0,
+            streams_destroyed_total: 0,
+            stream_data_orphan_count: 0,
         }
     }
 
@@ -1132,13 +1154,23 @@ impl DisplayChannel {
                         StreamState {
                             surface_id,
                             codec_type,
+                            stream_width: stream_w,
+                            stream_height: stream_h,
                             dest_top,
                             dest_left,
                             dest_bottom,
                             dest_right,
                             cached_dht: None,
+                            created_at_secs: self.traffic.elapsed().as_secs_f64(),
+                            frames_received: 0,
+                            frames_decoded_ok: 0,
+                            frames_decode_failed: 0,
+                            last_frame_ts_secs: None,
+                            last_decode_ok_ts_secs: None,
+                            last_decode_duration_us: 0,
                         },
                     );
+                    self.streams_created_total = self.streams_created_total.saturating_add(1);
                 }
             }
 
@@ -1171,6 +1203,10 @@ impl DisplayChannel {
                 };
 
                 if let Some(stream) = self.streams.get_mut(&stream_id) {
+                    let now_secs = self.traffic.elapsed().as_secs_f64();
+                    stream.frames_received = stream.frames_received.saturating_add(1);
+                    stream.last_frame_ts_secs = Some(now_secs);
+
                     if stream.codec_type == SPICE_VIDEO_CODEC_TYPE_MJPEG {
                         let (top, left, bottom, right) = dest.unwrap_or((
                             stream.dest_top,
@@ -1193,23 +1229,33 @@ impl DisplayChannel {
                             jpeg_data
                         };
 
-                        match decode_mjpeg_frame(frame_data) {
+                        let decode_start = std::time::Instant::now();
+                        let decoded = decode_mjpeg_frame(frame_data);
+                        let decode_duration_us =
+                            u32::try_from(decode_start.elapsed().as_micros()).unwrap_or(u32::MAX);
+
+                        match decoded {
                             Some((rgba, fw, fh)) => {
                                 debug!(
                                     "display: stream {} MJPEG frame {}x{} → ({},{})",
                                     stream_id, fw, fh, left, top
                                 );
+                                stream.frames_decoded_ok =
+                                    stream.frames_decoded_ok.saturating_add(1);
+                                stream.last_decode_ok_ts_secs = Some(now_secs);
+                                stream.last_decode_duration_us = decode_duration_us;
+                                let surface_id = stream.surface_id;
                                 self.event_tx
                                     .send(ChannelEvent::ImageReady {
                                         display_channel_id: self.channel_id,
-                                        surface_id: stream.surface_id,
+                                        surface_id,
                                         left,
                                         top,
                                         width: fw.min(w),
                                         height: fh.min(h),
                                         pixels: rgba,
                                         image_id: 0,
-                                        produced_at_secs: self.traffic.elapsed().as_secs_f64(),
+                                        produced_at_secs: now_secs,
                                     })
                                     .await
                                     .ok();
@@ -1217,6 +1263,8 @@ impl DisplayChannel {
                             }
                             None => {
                                 debug!("display: stream {} MJPEG decode failed", stream_id);
+                                stream.frames_decode_failed =
+                                    stream.frames_decode_failed.saturating_add(1);
                             }
                         }
                     } else {
@@ -1224,7 +1272,15 @@ impl DisplayChannel {
                             "display: stream {} unsupported codec {}",
                             stream_id, stream.codec_type
                         );
+                        stream.frames_decode_failed = stream.frames_decode_failed.saturating_add(1);
                     }
+                } else {
+                    self.stream_data_orphan_count = self.stream_data_orphan_count.saturating_add(1);
+                    debug!(
+                        "display: stream_data for unknown stream {} \
+                         (orphan_count={})",
+                        stream_id, self.stream_data_orphan_count
+                    );
                 }
             }
 
@@ -1239,7 +1295,10 @@ impl DisplayChannel {
                 if payload.len() >= 4 {
                     let stream_id = read_u32_le(payload, 0);
                     info!("display: stream_destroy id={}", stream_id);
-                    self.streams.remove(&stream_id);
+                    if self.streams.remove(&stream_id).is_some() {
+                        self.streams_destroyed_total =
+                            self.streams_destroyed_total.saturating_add(1);
+                    }
                 }
             }
 
@@ -1249,11 +1308,10 @@ impl DisplayChannel {
                 // change or surface reconfiguration. Equivalent to
                 // spice-gtk's clear_streams() at
                 // channel-display.c:1855.
-                info!(
-                    "display: stream_destroy_all (clearing {} streams)",
-                    self.streams.len()
-                );
+                let cleared = self.streams.len() as u64;
+                info!("display: stream_destroy_all (clearing {} streams)", cleared);
                 self.streams.clear();
+                self.streams_destroyed_total = self.streams_destroyed_total.saturating_add(cleared);
             }
 
             display_server::STREAM_ACTIVATE_REPORT => {
@@ -2287,6 +2345,40 @@ impl DisplayChannel {
 
         // Phase-02: pcap writer-queue drop counter.
         snap.writer_dropped_count = self.capture_dropped_count;
+
+        // Stream diagnostics: copy per-stream counters and the
+        // aggregate totals so a bug report can answer "did MJPEG
+        // frames arrive / decode / paint?" directly. Streams are
+        // listed in stream_id order for stable JSON output.
+        let mut stream_ids: Vec<u32> = self.streams.keys().copied().collect();
+        stream_ids.sort_unstable();
+        snap.streams_active = stream_ids
+            .into_iter()
+            .map(|id| {
+                let s = &self.streams[&id];
+                StreamSnapshot {
+                    stream_id: id,
+                    surface_id: s.surface_id,
+                    codec_type: s.codec_type,
+                    stream_width: s.stream_width,
+                    stream_height: s.stream_height,
+                    dest_top: s.dest_top,
+                    dest_left: s.dest_left,
+                    dest_bottom: s.dest_bottom,
+                    dest_right: s.dest_right,
+                    created_at_secs: s.created_at_secs,
+                    frames_received: s.frames_received,
+                    frames_decoded_ok: s.frames_decoded_ok,
+                    frames_decode_failed: s.frames_decode_failed,
+                    last_frame_ts_secs: s.last_frame_ts_secs,
+                    last_decode_ok_ts_secs: s.last_decode_ok_ts_secs,
+                    last_decode_duration_us: s.last_decode_duration_us,
+                }
+            })
+            .collect();
+        snap.streams_created_total = self.streams_created_total;
+        snap.streams_destroyed_total = self.streams_destroyed_total;
+        snap.stream_data_orphan_count = self.stream_data_orphan_count;
     }
 
     async fn send_ack(&mut self) -> Result<()> {

--- a/shakenfist-spice-renderer/src/lib.rs
+++ b/shakenfist-spice-renderer/src/lib.rs
@@ -44,7 +44,7 @@ pub use notification_sink::NotificationSink;
 pub use session::{run_connection, run_headless};
 pub use snapshots::{
     ChannelSnapshots, CursorCacheEntry, CursorSnapshot, DecodeResult, DisplaySnapshot,
-    InputEventRecord, InputsSnapshot, MainSnapshot,
+    InputEventRecord, InputsSnapshot, MainSnapshot, StreamSnapshot,
 };
 pub use surface_mirror::SurfaceMirror;
 pub use traffic::TrafficSink;

--- a/shakenfist-spice-renderer/src/snapshots.rs
+++ b/shakenfist-spice-renderer/src/snapshots.rs
@@ -11,6 +11,57 @@ use std::sync::{Arc, Mutex};
 
 use serde::Serialize;
 
+/// Per-stream state for a single SPICE display video stream
+/// (e.g. an MJPEG stream the server promoted a region to). One
+/// instance per currently-open `STREAM_CREATE` lives in
+/// `DisplaySnapshot::streams_active`; entries disappear when the
+/// server sends `STREAM_DESTROY` / `STREAM_DESTROY_ALL`.
+///
+/// Added to answer "is the MJPEG path actually painting?" from
+/// bug reports: `frames_received` reflects what arrived on the
+/// wire for this stream, `frames_decoded_ok` reflects what was
+/// blit to the surface, and the timestamps show staleness. See
+/// the diagnostic gap that motivated this in the renderer's
+/// stream handling (`channels/display.rs::STREAM_DATA`).
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct StreamSnapshot {
+    pub stream_id: u32,
+    pub surface_id: u32,
+    /// Raw SPICE codec type (1=MJPEG, 2=VP8, 3=H264, 4=VP9, 5=H265).
+    pub codec_type: u8,
+    /// Native stream dimensions reported by `STREAM_CREATE`.
+    pub stream_width: u32,
+    pub stream_height: u32,
+    /// Destination rect on the surface (where decoded frames blit).
+    pub dest_top: u32,
+    pub dest_left: u32,
+    pub dest_bottom: u32,
+    pub dest_right: u32,
+    /// Session-relative seconds when `STREAM_CREATE` was processed.
+    pub created_at_secs: f64,
+    /// `STREAM_DATA` / `STREAM_DATA_SIZED` messages received for
+    /// this stream since `STREAM_CREATE`. Includes frames the
+    /// codec was unable to decode.
+    pub frames_received: u64,
+    /// Frames successfully decoded and dispatched as `ImageReady`.
+    pub frames_decoded_ok: u64,
+    /// Frames where the MJPEG decoder returned `None` (decode
+    /// error or unsupported pixel format) or the codec is not
+    /// supported by the renderer (anything other than MJPEG today).
+    pub frames_decode_failed: u64,
+    /// Session-relative seconds of the most recent `STREAM_DATA`
+    /// message for this stream. None until the first one arrives.
+    pub last_frame_ts_secs: Option<f64>,
+    /// Session-relative seconds of the most recent successful
+    /// decode. None until the first one succeeds. Compare with
+    /// `last_frame_ts_secs` to see "frames arriving but not
+    /// decoding".
+    pub last_decode_ok_ts_secs: Option<f64>,
+    /// Wall-clock microseconds for the most recent successful
+    /// decode. Zero until the first one succeeds.
+    pub last_decode_duration_us: u32,
+}
+
 /// Result of a single image decode in the display channel.
 #[derive(Debug, Clone, Serialize)]
 pub struct DecodeResult {
@@ -104,6 +155,20 @@ pub struct DisplaySnapshot {
     /// when triaging a "video not keeping up" report. See
     /// PLAN-video-keeping-up-phase-02-pcap-thread.md.
     pub writer_dropped_count: u64,
+    /// Currently-open SPICE video streams (one entry per active
+    /// `STREAM_CREATE`). Empty when the server has not promoted
+    /// any region to a stream. See `StreamSnapshot`.
+    pub streams_active: Vec<StreamSnapshot>,
+    /// Cumulative `STREAM_CREATE` count since session start.
+    pub streams_created_total: u64,
+    /// Cumulative count of streams removed via `STREAM_DESTROY`
+    /// or `STREAM_DESTROY_ALL` since session start.
+    pub streams_destroyed_total: u64,
+    /// `STREAM_DATA` / `STREAM_DATA_SIZED` messages whose
+    /// `stream_id` did not match any open stream. A non-zero
+    /// value points at a `STREAM_CREATE` we missed or processed
+    /// in the wrong order — symptom level, not root cause.
+    pub stream_data_orphan_count: u64,
 }
 
 /// A recorded input event for the inputs channel snapshot.


### PR DESCRIPTION
Add per-stream counters and aggregate totals to DisplaySnapshot so a bug report can directly answer "did MJPEG frames arrive, decode, and reach blit?" without enabling debug logging.

New StreamSnapshot fields (one entry per open SPICE video stream): stream_id, surface_id, codec_type, stream/dest dimensions, created_at_secs, frames_received, frames_decoded_ok, frames_decode_failed, last_frame_ts_secs, last_decode_ok_ts_secs, last_decode_duration_us. Aggregate fields on DisplaySnapshot: streams_created_total, streams_destroyed_total,
stream_data_orphan_count.

Motivated by a macOS test session (test-session-002) where audio played but video was effectively frozen. The existing display snapshot could not distinguish "server never sent stream data" from "frames arrived but decode failed" from "decoded ok but blit/repaint broken" -- frames_received and decode_total_count together gave a 38-frame upper bound on non-image-decode ImageReady events over a 246s session, which is suggestive but not conclusive. The per-stream counters make the next bug report definitive.

Counters are wired into STREAM_CREATE (created_at, dimensions, streams_created_total++), STREAM_DATA / STREAM_DATA_SIZED (frames_received++, time the decode, bump ok/failed and last timestamps, or stream_data_orphan_count++ for an unknown stream_id), and STREAM_DESTROY / STREAM_DESTROY_ALL (streams_destroyed_total++).

Prompt: User reported a bad macOS test session where browser video playback produced audio but only ~30s-interval display updates. After investigating the bug reports and tracing the SPICE display channel's MJPEG stream handling end to end, we could not confirm from existing instrumentation whether MJPEG frames were even reaching the blit step. User asked me to add per-stream instrumentation so the next bug report can answer this directly.