### PR TITLE
Headless: log SPICE connection task errors.

### DIFF
--- a/shakenfist-spice-renderer/src/session.rs
+++ b/shakenfist-spice-renderer/src/session.rs
@@ -841,8 +841,12 @@ pub async fn run_headless(
                     last_stats_print = Instant::now();
                 }
             }
-            _ = &mut connection_handle => {
-                info!("Connection task completed");
+            join_result = &mut connection_handle => {
+                match join_result {
+                    Ok(Ok(())) => info!("Connection task completed"),
+                    Ok(Err(e)) => error!("Connection task failed: {:#}", e),
+                    Err(e) => error!("Connection task panicked: {}", e),
+                }
                 break;
             }
             // Poll the host's cancel flag at a reasonable interval. The host


### PR DESCRIPTION
The headless event loop matched the SPICE connection task's `JoinHandle` with `_ = &mut connection_handle` and only logged "Connection task completed".  Whatever `Err` the task carried -- TCP refusal, TLS handshake failure, link-handshake error -- was silently discarded, leaving operators with no signal at all when ryll bailed out mid-connect.

Bind the join result and match on it: `Ok(Ok(()))` keeps the existing info line; an inner `Err` is logged at error level with the anyhow chain (`{:#}`) so the rustls / tcp / link error surfaces in the artifact; a `JoinError` is logged as a panic so that case is no longer indistinguishable from a clean exit.

Prompt: while investigating a kerbside CI failure where ryll exits within 4 ms of launch with only "Connection task completed", surface the connection task's error so the underlying TCP/TLS/handshake failure reaches the log.  The kerbside-side diagnostics (RUST_LOG=debug) turned out to be inert because ryll does not honour RUST_LOG; this is the change that would have made the error visible regardless.


Assisted-By: Claude Opus 4.7 (1M context, low effort) <noreply@anthropic.com>