### PR TITLE
SPICE auth: NUL-terminate the encrypted password.

### DIFF
--- a/shakenfist-spice-protocol/src/link.rs
+++ b/shakenfist-spice-protocol/src/link.rs
@@ -259,7 +259,23 @@ pub fn encrypt_password(pub_key_bytes: &[u8], password: &str) -> Result<Vec<u8>>
     let padding = Oaep::new::<Sha1>();
     let mut rng = OsRng;
 
-    let encrypted = pub_key.encrypt(&mut rng, padding, password.as_bytes())?;
+    // SPICE auth convention is a NUL-terminated plaintext.  Every
+    // reference implementation does this and every spec-compliant
+    // server depends on it:
+    //   spice-gtk  (spice-channel.c:1265,1273,1282): encrypts
+    //              `strlen(password) + 1` bytes.
+    //   spice-html5 (spiceconn.js:274): sends
+    //              `this.password + String.fromCharCode(0)`.
+    //   spice-server (reds.cpp:2086): writes `password[len] = '\0'`
+    //              before `strcmp`, treating the decrypted blob as
+    //              a C string.
+    // Omitting the NUL causes any server that strips a trailing
+    // sentinel byte (kerbside does this too) to chop the last
+    // character of the real password and reject the auth.
+    let mut plaintext = Vec::with_capacity(password.len() + 1);
+    plaintext.extend_from_slice(password.as_bytes());
+    plaintext.push(0);
+    let encrypted = pub_key.encrypt(&mut rng, padding, &plaintext)?;
 
     // Pad to 128 bytes (RSA block size)
     let mut result = vec![0u8; 128];


### PR DESCRIPTION
`encrypt_password` was passing `password.as_bytes()` straight to RSA-OAEP, omitting the trailing NUL that every reference SPICE implementation includes.  The reference convention is consistent:

  spice-gtk (spice-channel.c:1265,1273,1282)
      encrypts `strlen(password) + 1` bytes.
  spice-html5 (spiceconn.js:274)
      `this.password + String.fromCharCode(0)`.
  spice-server (reds.cpp:2086)
      writes `password[len] = '\0'` then compares with `strcmp`,
      i.e. treats the decrypted blob as a NUL-terminated C string.

Servers that strip the trailing sentinel byte before lookup (kerbside does this in proxy.py too) therefore chop the last character of the real password when ryll talks to them, and the auth lookup always fails.  This was the root cause of the kerbside test-harness CI failure where every connection died with "Client token is invalid, closing connection" immediately after the TLS handshake.

Push a NUL byte onto the plaintext before encryption to match spice-gtk / spice-html5 / spice-server.

Prompt: kerbside CI now gets through TLS but the proxy rejects ryll's SPICE auth as "client token invalid".  After triple- checking spice-gtk, spice-html5, and spice-server source, the NUL terminator is the universal convention and ryll is the outlier.  Make ryll conform.


Assisted-By: Claude Opus 4.7 (1M context, low effort) <noreply@anthropic.com>