### PR TITLE
Update Rust crate quinn-proto to v0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2198,7 +2198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5149,9 +5149,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -5747,7 +5747,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5815,7 +5815,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6613,7 +6613,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7950,7 +7950,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `quinn-proto` 0.11.14 → 0.11.15 to fix **RUSTSEC-2026-0185**
(GHSA-4w2j-m93h-cj5j, published 2026-06-22): remote memory exhaustion
via unbounded out-of-order stream reassembly. quinn-proto enters the
tree transitively through `reqwest`. The advisory is fixed in 0.11.15,
a semver-compatible patch release.

This is a real fix rather than a suppression, so `deny.toml` and
`.cargo/audit.toml` are unchanged. The lockfile also carries the
`windows-sys` 0.52 → 0.59 churn that current resolution produces; this
is identical to what already passes CI on the open rustls (#128) and
nusb (#126) dependency PRs, and only affects Windows-only crates.

Clearing this advisory on `develop` also unblocks the `cargo audit`
check on the open dependency PRs #126, #127 and #128, which are all
inheriting the same failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)